### PR TITLE
Allow user to specify number of itineraries

### DIFF
--- a/lib/open_trip_planner_client/plan_params.ex
+++ b/lib/open_trip_planner_client/plan_params.ex
@@ -13,6 +13,7 @@ defmodule OpenTripPlannerClient.PlanParams do
     :date,
     :time,
     arriveBy: false,
+    numItineraries: 5,
     transportModes: [%{mode: :WALK}, %{mode: :TRANSIT}],
     wheelchair: false
   ]
@@ -101,6 +102,7 @@ defmodule OpenTripPlannerClient.PlanParams do
           arriveBy: arrive_by(),
           fromPlace: place(),
           date: date(),
+          numItineraries: integer(),
           time: time(),
           toPlace: place(),
           transportModes: transport_modes(),

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -6,6 +6,7 @@ query TripPlan(
   $arriveBy: Boolean
   $wheelchair: Boolean
   $transportModes: [TransportMode]
+  $numItineraries: Int
 ) {
   plan(
     fromPlace: $fromPlace
@@ -20,7 +21,7 @@ query TripPlan(
     searchWindow: 7200
 
     # Increased from 3 to offer more itineraries for potential post-processing
-    numItineraries: 5
+    numItineraries: $numItineraries
 
     # Increased from 2.0 to reduce number of itineraries with significant walking
     walkReluctance: 5.0

--- a/test/open_trip_planner_client/plan_params_test.exs
+++ b/test/open_trip_planner_client/plan_params_test.exs
@@ -18,6 +18,18 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
     assert to_time_param(now) == time
   end
 
+  test "new/1 defaults to having 5 itineraries" do
+    assert %OpenTripPlannerClient.PlanParams{
+             numItineraries: 5
+           } = new()
+  end
+
+  test "new/1 allows a customizable number of itineraries" do
+    assert %OpenTripPlannerClient.PlanParams{
+             numItineraries: 42
+           } = new(%{numItineraries: 42})
+  end
+
   test "to_place_param/1 with stop" do
     name = Faker.App.name()
     stop_id = Faker.Internet.slug()


### PR DESCRIPTION
This keeps the default at 5, but allows the caller to specify whatever number of itineraries they want.

Rationale: If the next 5 trips from point A to point B include one on the Park St --> Copley branch, one with the C branch and one with the D branch then we'll erroneously say C/D, rather than the more accurate B/C/D/E. Getting some much larger number of trips (like 40, or 100, or something) would keep us from leaving out relevant trips, and it would be nice to iterate on exactly how many trips to get from OTP without having to cut a release each time.

Also, Ye Olde Trip Planner probably still wants 5 trips.

Original PR:
- https://github.com/thecristen/open_trip_planner_client/pull/5