### PR TITLE
feat(ItineraryTag): support sort by itinerary end time

### DIFF
--- a/lib/open_trip_planner_client/itinerary_tag.ex
+++ b/lib/open_trip_planner_client/itinerary_tag.ex
@@ -123,10 +123,15 @@ defmodule OpenTripPlannerClient.ItineraryTag do
     |> Map.drop([:candidate_tags])
   end
 
-  @spec sort_tagged([Behaviour.itinerary_map()]) :: [Behaviour.itinerary_map()]
-  def sort_tagged(tagged_itineraries) do
+  @doc """
+  Sorts first by tag name, then chronologically. While default behavior sorts
+  itineraries by start time, can also support sort by itinerary end time.
+  """
+  @spec sort_tagged([Behaviour.itinerary_map()], :start | :end) :: [Behaviour.itinerary_map()]
+  def sort_tagged(tagged_itineraries, start_or_end \\ :start) do
     chrono_sorter = fn itinerary ->
-      itinerary.start
+      itinerary
+      |> Map.get(start_or_end)
       |> DateTime.to_unix()
     end
 

--- a/test/open_trip_planner_client/itinerary_tag_test.exs
+++ b/test/open_trip_planner_client/itinerary_tag_test.exs
@@ -100,4 +100,36 @@ defmodule OpenTripPlannerClient.ItineraryTagTest do
              %{tag: nil}
            ] = sorted
   end
+
+  test "sort_tagged/2 supports sort by end time" do
+    end_dt = Faker.DateTime.forward(1)
+    end_dt1 = Timex.shift(end_dt, hours: 1)
+    end_dt2 = Timex.shift(end_dt, hours: 2)
+
+    itineraries = [
+      build(:itinerary, %{end: end_dt})
+      |> Map.put(:tag, :least_walking),
+      build(:itinerary, %{end: end_dt})
+      |> Map.put(:tag, nil),
+      build(:itinerary, %{end: end_dt1})
+      |> Map.put(:tag, :least_walking),
+      build(:itinerary, %{end: end_dt2})
+      |> Map.put(:tag, :least_walking),
+      build(:itinerary, %{end: end_dt2})
+      |> Map.put(:tag, :earliest_arrival),
+      build(:itinerary, %{end: end_dt1})
+      |> Map.put(:tag, :most_direct)
+    ]
+
+    sorted = ItineraryTag.sort_tagged(itineraries, :end)
+
+    assert [
+             %{tag: :most_direct},
+             %{tag: :earliest_arrival},
+             %{tag: :least_walking, end: ^end_dt},
+             %{tag: :least_walking, end: ^end_dt1},
+             %{tag: :least_walking, end: ^end_dt2},
+             %{tag: nil}
+           ] = sorted
+  end
 end


### PR DESCRIPTION
Default behavior is kept the same, but this adds support to optionally sort itineraries by end instead of start time. This is compelling in the case where we're planning a trip to **_arrive_** by a certain time. :) 