### PR TITLE
feat(ItineraryGroup): group itineraries together

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -33,9 +33,10 @@ jobs:
     needs: setup
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: ./.github/actions/setup
-      - run: git fetch origin main:main
-      - run: mix credo diff --from-git-merge-base main -a --strict
+      - run: mix credo diff --from-git-merge-base ${{ github.event.pull_request.base.sha }} -a --strict
 
   dialyzer:
     runs-on: ubuntu-latest

--- a/lib/open_trip_planner_client/itinerary_group.ex
+++ b/lib/open_trip_planner_client/itinerary_group.ex
@@ -22,22 +22,29 @@ defmodule OpenTripPlannerClient.ItineraryGroup do
   ]
 
   @max_per_group 4
+  @num_groups 5
   @short_walk_threshold_minutes 5
 
   @doc """
-  From a large list of itineraries, collect them into 5 groups of at most
+  From a large list of itineraries, collect them into #{@num_groups} groups of at most
   #{@max_per_group} itineraries each, sorting the groups in favor of tagged
-  groups first
+  groups first.
+
+  A different numbers of groups can be specified via the second argument.
+
+  ```elixir
+  _ = groups_from_itineraries(itineraries, num_groups: 8)
+  ```
   """
-  @spec from_itineraries([Itinerary.t()], Keyword.t()) :: [%__MODULE__{}]
-  def from_itineraries(itineraries, opts \\ []) do
+  @spec groups_from_itineraries([Itinerary.t()], Keyword.t()) :: [%__MODULE__{}]
+  def groups_from_itineraries(itineraries, opts \\ []) do
     itineraries
     |> Enum.group_by(&Itinerary.group_identifier/1)
     |> Enum.map(&truncate_list(&1, opts))
     |> Enum.reject(&Enum.empty?/1)
     |> Enum.map(&to_group(&1, opts))
     |> Enum.sort_by(&tag_priority/1)
-    |> Enum.take(5)
+    |> Enum.take(Keyword.get(opts, :num_groups, @num_groups))
   end
 
   defp truncate_list({_, grouped_itineraries}, opts) do

--- a/lib/open_trip_planner_client/itinerary_group.ex
+++ b/lib/open_trip_planner_client/itinerary_group.ex
@@ -1,0 +1,170 @@
+defmodule OpenTripPlannerClient.ItineraryGroup do
+  @moduledoc """
+  Group itineraries by unique legs.
+
+  A unique leg is defined as a leg that has a unique combination of mode, from, and to.
+  But, this does not include walking legs that are less than 0.2 miles.
+  """
+
+  alias OpenTripPlannerClient.ItineraryTag
+  alias OpenTripPlannerClient.Schema.{Itinerary, Leg, Route}
+
+  @type t :: %__MODULE__{
+          itineraries: [Itinerary.t()],
+          representative_index: non_neg_integer(),
+          time_key: :start | :end
+        }
+
+  defstruct [
+    :itineraries,
+    :representative_index,
+    :time_key
+  ]
+
+  @max_per_group 4
+  @short_walk_threshold_minutes 5
+
+  @doc """
+  From a large list of itineraries, collect them into 5 groups of at most
+  #{@max_per_group} itineraries each, sorting the groups in favor of tagged
+  groups first
+  """
+  @spec from_itineraries([Itinerary.t()], Keyword.t()) :: [%__MODULE__{}]
+  def from_itineraries(itineraries, opts \\ []) do
+    itineraries
+    |> Enum.group_by(&Itinerary.group_identifier/1)
+    |> Enum.map(&truncate_list(&1, opts))
+    |> Enum.reject(&Enum.empty?/1)
+    |> Enum.map(&to_group(&1, opts))
+    |> Enum.sort_by(&tag_priority/1)
+    |> Enum.take(5)
+  end
+
+  defp truncate_list({_, grouped_itineraries}, opts) do
+    if opts[:take_from_end] do
+      grouped_itineraries
+      |> ItineraryTag.sort_tagged(:end)
+      |> Enum.take(-@max_per_group)
+    else
+      grouped_itineraries
+      |> ItineraryTag.sort_tagged(:start)
+      |> Enum.take(@max_per_group)
+    end
+  end
+
+  defp to_group(grouped_itineraries, opts) do
+    representative_index = if(opts[:take_from_end], do: -1, else: 0)
+    time_key = if(opts[:take_from_end], do: :end, else: :start)
+
+    %__MODULE__{
+      itineraries: grouped_itineraries,
+      representative_index: representative_index,
+      time_key: time_key
+    }
+  end
+
+  @spec leg_summaries(__MODULE__.t()) :: [%{walk_minutes: non_neg_integer(), routes: [Route.t()]}]
+  def leg_summaries(%__MODULE__{itineraries: itineraries}) do
+    itineraries
+    |> Enum.map(& &1.legs)
+    |> Enum.zip_with(&Function.identity/1)
+    |> Enum.map(&aggregate_legs/1)
+    |> remove_short_intermediate_walks()
+  end
+
+  defp aggregate_legs(legs) do
+    legs
+    |> Enum.uniq_by(&combined_leg_to_tuple/1)
+    |> Enum.reduce(%{walk_minutes: 0, routes: []}, &summarize_legs/2)
+  end
+
+  defp combined_leg_to_tuple(%Leg{transit_leg: false} = leg) do
+    Leg.group_identifier(leg)
+  end
+
+  defp combined_leg_to_tuple(%Leg{route: route} = leg) do
+    {route.gtfs_id, leg.from.name, leg.to.name}
+  end
+
+  defp summarize_legs(%Leg{duration: duration, transit_leg: false}, summary) do
+    minutes = Timex.Duration.to_minutes(duration, :seconds)
+
+    summary
+    |> Map.update!(:walk_minutes, &(&1 + minutes))
+  end
+
+  defp summarize_legs(%Leg{route: route}, summary) do
+    summary
+    |> Map.update!(:routes, fn routes ->
+      [route | routes]
+      |> Enum.sort_by(& &1.sort_order)
+    end)
+  end
+
+  defp remove_short_intermediate_walks(summarized_legs) do
+    summarized_legs
+    |> Enum.with_index()
+    |> Enum.reject(fn {leg, index} ->
+      index > 0 && index < length(summarized_legs) - 1 &&
+        (leg.routes == [] && leg.walk_minutes < @short_walk_threshold_minutes)
+    end)
+    |> Enum.map(fn {leg, _} -> leg end)
+  end
+
+  @spec tag_priority(__MODULE__.t()) :: non_neg_integer() | nil
+  defp tag_priority(itinerary_group) do
+    itinerary_group
+    |> representative_itinerary()
+    |> Map.get(:tag)
+    |> then(fn representative_tag ->
+      Enum.find_index(
+        ItineraryTag.tag_priority_order(),
+        &(&1 == representative_tag)
+      )
+    end)
+  end
+
+  @spec representative_itinerary(__MODULE__.t()) :: Itinerary.t()
+  def representative_itinerary(%__MODULE__{
+        itineraries: itineraries,
+        representative_index: representative_index
+      }) do
+    Enum.at(itineraries, representative_index, List.first(itineraries))
+  end
+
+  @spec all_times(__MODULE__.t()) :: [DateTime.t()]
+  def all_times(%__MODULE__{itineraries: itineraries, time_key: time_key}) do
+    Enum.map(itineraries, &Map.get(&1, time_key))
+  end
+
+  @doc """
+  Formatted list of times arriving or departing.
+  """
+  @spec alternatives_text(__MODULE__.t()) :: String.t() | nil
+  @spec alternatives_text([DateTime.t()], :start | :end) :: String.t() | nil
+  def alternatives_text(
+        %__MODULE__{representative_index: representative_index, time_key: time_key} =
+          itinerary_group
+      ) do
+    itinerary_group
+    |> all_times()
+    |> List.delete_at(representative_index)
+    |> alternatives_text(time_key)
+  end
+
+  @doc """
+  Formatted list of times arriving or departing.
+  """
+  @spec alternatives_text([DateTime.t()], :start | :end) :: String.t() | nil
+  def alternatives_text([], _), do: nil
+  def alternatives_text([time], :start), do: "Similar trip departs at #{time(time)}"
+  def alternatives_text([time], :end), do: "Similar trip arrives at #{time(time)}"
+
+  def alternatives_text(times, :start),
+    do: "Similar trips depart at #{Enum.map_join(times, ", ", &time/1)}"
+
+  def alternatives_text(times, :end),
+    do: "Similar trips arrive at #{Enum.map_join(times, ", ", &time/1)}"
+
+  defp time(time), do: Timex.format!(time, "%-I:%M", :strftime)
+end

--- a/lib/open_trip_planner_client/itinerary_tag.ex
+++ b/lib/open_trip_planner_client/itinerary_tag.ex
@@ -137,7 +137,7 @@ defmodule OpenTripPlannerClient.ItineraryTag do
 
     priority_sorter = fn itinerary ->
       @tag_priority_order
-      |> Enum.find_index(&(&1 === itinerary.tag))
+      |> Enum.find_index(&(&1 === itinerary[:tag]))
     end
 
     tagged_itineraries

--- a/lib/open_trip_planner_client/schema/itinerary.ex
+++ b/lib/open_trip_planner_client/schema/itinerary.ex
@@ -54,7 +54,7 @@ defmodule OpenTripPlannerClient.Schema.Itinerary do
   - Same grouped legs*
     - Disregarding very short walking legs up to 0.2 mi
   """
-  @spec group_identifier(__MODULE__.t()) :: Tuple.t()
+  @spec group_identifier(__MODULE__.t()) :: tuple()
   def group_identifier(itinerary) do
     leg_groups =
       itinerary.legs

--- a/lib/open_trip_planner_client/schema/itinerary.ex
+++ b/lib/open_trip_planner_client/schema/itinerary.ex
@@ -27,4 +27,47 @@ defmodule OpenTripPlannerClient.Schema.Itinerary do
     field(:start, offset_datetime())
     field(:walk_distance, distance_meters())
   end
+
+  @doc """
+   Is the itinerary accessible? It's mostly a straightforward matter
+   of whether its accessibility score is equal to 1, but the MBTA also
+   considers any trips on its bus fleet accessible, regardless of
+   accessibility-impacting particularities of individual bus stops.
+  """
+  @spec accessible?(__MODULE__.t()) :: boolean() | nil
+  def accessible?(%__MODULE__{accessibility_score: nil}), do: nil
+  def accessible?(%__MODULE__{accessibility_score: 1.0}), do: true
+
+  def accessible?(%__MODULE__{legs: legs}) do
+    all_mbta_legs?(legs)
+  end
+
+  defp all_mbta_legs?(legs) do
+    legs
+    |> Enum.filter(& &1.transit_leg)
+    |> Enum.all?(&(&1.route.type == 3 && &1.agency.name == "MBTA"))
+  end
+
+  @doc """
+  To be grouped together, itineraries must share these characteristics:
+  - Same accessible? value
+  - Same grouped legs*
+    - Disregarding very short walking legs up to 0.2 mi
+  """
+  @spec group_identifier(__MODULE__.t()) :: Tuple.t()
+  def group_identifier(itinerary) do
+    leg_groups =
+      itinerary.legs
+      |> Enum.reject(&short_walking_leg?/1)
+      |> Enum.map(&Leg.group_identifier/1)
+
+    {accessible?(itinerary), leg_groups}
+  end
+
+  defp short_walking_leg?(%Leg{transit_leg: false, distance: meters}) do
+    miles = Float.ceil(meters / 1609.34, 1)
+    miles <= 0.2
+  end
+
+  defp short_walking_leg?(_), do: false
 end

--- a/lib/open_trip_planner_client/schema/itinerary.ex
+++ b/lib/open_trip_planner_client/schema/itinerary.ex
@@ -39,10 +39,10 @@ defmodule OpenTripPlannerClient.Schema.Itinerary do
   def accessible?(%__MODULE__{accessibility_score: 1.0}), do: true
 
   def accessible?(%__MODULE__{legs: legs}) do
-    all_mbta_legs?(legs)
+    all_mbta_bus_legs?(legs)
   end
 
-  defp all_mbta_legs?(legs) do
+  defp all_mbta_bus_legs?(legs) do
     legs
     |> Enum.filter(& &1.transit_leg)
     |> Enum.all?(&(&1.route.type == 3 && &1.agency.name == "MBTA"))

--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -109,7 +109,7 @@ defmodule OpenTripPlannerClient.Schema.Leg do
   - Same :transit_leg value (e.g. walking legs don't get grouped with transit legs)
   - Same transit route.type, except for rail replacement buses
   """
-  @spec group_identifier(__MODULE__.t()) :: Tuple.t()
+  @spec group_identifier(__MODULE__.t()) :: tuple()
   def group_identifier(%__MODULE__{transit_leg: false} = leg) do
     {:WALK, leg.from.name, leg.to.name}
   end

--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -102,4 +102,19 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     do: {:ok, OpenTripPlannerClient.Util.to_existing_atom(string)}
 
   def to_atom(other), do: {:ok, other}
+
+  @doc """
+  To be grouped together, legs must share these characteristics:
+  - Same origin and destination
+  - Same :transit_leg value (e.g. walking legs don't get grouped with transit legs)
+  - Same transit route.type, except for rail replacement buses
+  """
+  @spec group_identifier(__MODULE__.t()) :: Tuple.t()
+  def group_identifier(%__MODULE__{transit_leg: false} = leg) do
+    {:WALK, leg.from.name, leg.to.name}
+  end
+
+  def group_identifier(%__MODULE__{route: %Route{desc: desc, type: type}} = leg) do
+    {type, desc == "Rail Replacement Bus", leg.from.name, leg.to.name}
+  end
 end

--- a/test/open_trip_planner_client/itinerary_group_test.exs
+++ b/test/open_trip_planner_client/itinerary_group_test.exs
@@ -1,0 +1,166 @@
+defmodule OpenTripPlannerClient.ItineraryGroupTest do
+  use ExUnit.Case, async: true
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
+  alias OpenTripPlannerClient.ItineraryGroup
+  alias OpenTripPlannerClient.Schema.Itinerary
+
+  describe "from_itineraries/2" do
+    test "can group itineraries separately" do
+      itineraries = build_list(3, :itinerary)
+      groups = ItineraryGroup.from_itineraries(itineraries)
+
+      for group <- groups do
+        assert %ItineraryGroup{} = group
+      end
+    end
+
+    test "can group itineraries together" do
+      groupable_itineraries = groupable_otp_itineraries(1, 3)
+
+      [%ItineraryGroup{} = group] =
+        ItineraryGroup.from_itineraries(groupable_itineraries)
+
+      assert Enum.count(group.itineraries) == Enum.count(groupable_itineraries)
+    end
+
+    test "doesn't exceed 4 per group" do
+      many_groupable_itineraries = groupable_otp_itineraries(1, 20)
+
+      [%ItineraryGroup{} = group] =
+        ItineraryGroup.from_itineraries(many_groupable_itineraries)
+
+      assert Enum.count(group.itineraries) == 4
+    end
+
+    test "can adjust representative_index" do
+      groupable_itineraries = groupable_otp_itineraries(1, 3)
+
+      [%ItineraryGroup{} = group1] =
+        ItineraryGroup.from_itineraries(groupable_itineraries, take_from_end: true)
+
+      [%ItineraryGroup{} = group2] =
+        ItineraryGroup.from_itineraries(groupable_itineraries, take_from_end: false)
+
+      assert group1.representative_index == -1
+      assert group2.representative_index == 0
+    end
+
+    test "can adjust time_key" do
+      groupable_itineraries = groupable_otp_itineraries(1, 3)
+
+      [%ItineraryGroup{} = group1] =
+        ItineraryGroup.from_itineraries(groupable_itineraries, take_from_end: true)
+
+      [%ItineraryGroup{} = group2] =
+        ItineraryGroup.from_itineraries(groupable_itineraries, take_from_end: false)
+
+      assert group1.time_key == :end
+      assert group2.time_key == :start
+    end
+  end
+
+  describe "leg_summaries/1" do
+    setup do
+      groupable_itineraries = groupable_otp_itineraries(1, 3)
+      group = ItineraryGroup.from_itineraries(groupable_itineraries) |> List.first()
+      {:ok, %{group: group}}
+    end
+
+    test "returns list of either walking minutes or transit routes", %{group: group} do
+      assert leg_summaries = ItineraryGroup.leg_summaries(group)
+
+      for %{walk_minutes: walk_minutes, routes: grouped_routes} <- leg_summaries do
+        assert walk_minutes > 0 or length(grouped_routes) > 0
+      end
+    end
+
+    test "groups overlapping routes together" do
+      route = build(:route, type: 2)
+      related_route = build(:route, type: 2)
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+
+      itinerary =
+        build(:itinerary, legs: build_list(1, :transit_leg, route: route, from: from, to: to))
+
+      related_itinerary =
+        build(:itinerary,
+          legs: build_list(1, :transit_leg, route: related_route, from: from, to: to)
+        )
+
+      [group] = [itinerary, related_itinerary] |> ItineraryGroup.from_itineraries()
+      assert [%{routes: grouped_routes}] = ItineraryGroup.leg_summaries(group)
+      assert Enum.sort(grouped_routes) == Enum.sort([route, related_route])
+    end
+
+    test "omits short intermediate walks" do
+      short_leg = build(:walking_leg, duration: 60)
+      long_leg = build(:walking_leg, duration: 600)
+
+      [group] =
+        build_list(2, :itinerary, legs: [long_leg, short_leg, long_leg])
+        |> ItineraryGroup.from_itineraries()
+
+      assert [%{walk_minutes: 10.0}, %{walk_minutes: 10.0}] = ItineraryGroup.leg_summaries(group)
+    end
+  end
+
+  describe "representative_itinerary/1" do
+    test "picks based on group representative_index" do
+      group = build(:itinerary_group)
+      %Itinerary{} = representative_itinerary = ItineraryGroup.representative_itinerary(group)
+      assert representative_itinerary == Enum.at(group.itineraries, group.representative_index)
+    end
+  end
+
+  describe "all_times/1" do
+    test "picks times based on group time_key" do
+      group = build(:itinerary_group)
+      all_times = ItineraryGroup.all_times(group)
+      assert length(all_times) == length(group.itineraries)
+      assert all_times == Enum.map(group.itineraries, &Map.get(&1, group.time_key))
+    end
+  end
+
+  describe "alternatives_text/1" do
+    test "nil when no itinerary alternatives" do
+      group = build(:itinerary_group, itineraries: build_list(1, :itinerary))
+      refute ItineraryGroup.alternatives_text(group)
+    end
+
+    @tag flaky: "Sometimes multiple generated itineraries happen to have the same time!"
+    test "doesn't include representative_itinerary details" do
+      group = build(:itinerary_group)
+
+      representative_time =
+        group
+        |> ItineraryGroup.representative_itinerary()
+        |> Map.get(group.time_key)
+        |> Timex.format!("%-I:%M", :strftime)
+
+      refute ItineraryGroup.alternatives_text(group) =~ representative_time
+    end
+
+    test "changes based on group time_key" do
+      depart_group = build(:itinerary_group, time_key: :start)
+      arrive_group = %{depart_group | time_key: :end}
+      depart_alternatives = ItineraryGroup.alternatives_text(depart_group)
+      arrive_alternatives = ItineraryGroup.alternatives_text(arrive_group)
+      refute depart_alternatives == arrive_alternatives
+      assert depart_alternatives =~ "Similar trips depart at"
+      assert arrive_alternatives =~ "Similar trips arrive at"
+    end
+
+    test "changes on number of alternate times" do
+      group = build(:itinerary_group, time_key: :start, representative_index: 0)
+      smaller_group = %{group | itineraries: Enum.take(group.itineraries, 2)}
+      alternatives = ItineraryGroup.alternatives_text(group)
+      smaller_alternatives = ItineraryGroup.alternatives_text(smaller_group)
+      refute alternatives == smaller_alternatives
+      assert alternatives =~ "Similar trips depart at"
+      assert smaller_alternatives =~ "Similar trip departs at"
+    end
+  end
+end

--- a/test/open_trip_planner_client/schema/itinerary_test.exs
+++ b/test/open_trip_planner_client/schema/itinerary_test.exs
@@ -1,0 +1,61 @@
+defmodule ItineraryTest do
+  use ExUnit.Case, async: true
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
+  alias OpenTripPlannerClient.Schema.Itinerary
+
+  describe "accessible?" do
+    test "true with accessibility_score of 1" do
+      assert build(:itinerary, accessibility_score: 1.0) |> Itinerary.accessible?()
+    end
+
+    test "false with accessibility_score of nil" do
+      refute build(:itinerary, accessibility_score: nil) |> Itinerary.accessible?()
+    end
+
+    test "otherwise true if all transit legs are MBTA buses" do
+      accessibility_score = Faker.random_between(1, 99) / 100
+
+      itinerary =
+        build(:itinerary,
+          accessibility_score: accessibility_score,
+          legs: build_list(3, :mbta_bus_leg)
+        )
+
+      assert Itinerary.accessible?(itinerary)
+    end
+  end
+
+  describe "group_identifier/1" do
+    test "different value for otherwise identical itineraries with different accessibility scores" do
+      accessible_itinerary = build(:itinerary, accessibility_score: 1.0)
+      inaccessible_itinerary = %{accessible_itinerary | accessibility_score: nil}
+
+      assert Itinerary.group_identifier(accessible_itinerary) !=
+               Itinerary.group_identifier(inaccessible_itinerary)
+    end
+
+    test "same value for itineraries with same accessibility and same leg sequence" do
+      legs = build_list(3, :transit_leg)
+      itinerary = build(:itinerary, legs: legs, accessibility_score: nil)
+      other_itinerary = build(:itinerary, legs: legs, accessibility_score: nil)
+
+      assert Itinerary.group_identifier(itinerary) ==
+               Itinerary.group_identifier(other_itinerary)
+    end
+
+    test "same value for itineraries with same accessibility and simliar leg sequence" do
+      legs = build_list(3, :transit_leg)
+      short_walking_leg = build(:walking_leg, distance: 200)
+
+      itinerary = build(:itinerary, legs: legs, accessibility_score: nil)
+
+      other_itinerary =
+        build(:itinerary, legs: [short_walking_leg | legs], accessibility_score: nil)
+
+      assert Itinerary.group_identifier(itinerary) ==
+               Itinerary.group_identifier(other_itinerary)
+    end
+  end
+end

--- a/test/open_trip_planner_client/schema/leg_test.exs
+++ b/test/open_trip_planner_client/schema/leg_test.exs
@@ -1,0 +1,57 @@
+defmodule LegTest do
+  use ExUnit.Case, async: true
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
+  alias OpenTripPlannerClient.Schema.{Leg, Route}
+
+  describe "group_identifier/1" do
+    test "different value for legs between the same places using different mode" do
+      from = build(:place)
+      to = build(:place)
+      walking_leg = build(:walking_leg, from: from, to: to)
+      transit_leg = build(:transit_leg, from: from, to: to)
+
+      assert Leg.group_identifier(walking_leg) !=
+               Leg.group_identifier(transit_leg)
+    end
+
+    test "different value for legs between the same places using different route type" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+      route = build(:route)
+      transit_leg = build(:transit_leg, from: from, to: to, route: %{route | type: 0})
+      other_transit_leg = build(:transit_leg, from: from, to: to, route: %{route | type: 1})
+
+      assert Leg.group_identifier(transit_leg) !=
+               Leg.group_identifier(other_transit_leg)
+    end
+
+    test "same value for legs between the same places using same route type" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+      route_type = Faker.Util.pick(Route.gtfs_route_type())
+
+      transit_leg =
+        build(:transit_leg, from: from, to: to, route: build(:route, type: route_type))
+
+      other_transit_leg =
+        build(:transit_leg, from: from, to: to, route: build(:route, type: route_type))
+
+      assert Leg.group_identifier(transit_leg) ==
+               Leg.group_identifier(other_transit_leg)
+    end
+
+    test "different value for bus legs between the same places where one is a rail replacement bus" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+      bus_route = build(:route, type: 3, desc: "Local Bus")
+      rail_replacement_route = build(:route, type: 3, desc: "Rail Replacement Bus")
+      transit_leg = build(:transit_leg, from: from, to: to, route: bus_route)
+      other_transit_leg = build(:transit_leg, from: from, to: to, route: rail_replacement_route)
+
+      assert Leg.group_identifier(transit_leg) !=
+               Leg.group_identifier(other_transit_leg)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -227,6 +227,17 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
       }
     end
 
+    def place_with_stop_factory do
+      stop = build(:stop)
+
+      %Place{
+        name: stop.name,
+        lat: Faker.Address.latitude(),
+        lon: Faker.Address.longitude(),
+        stop: stop
+      }
+    end
+
     def route_factory do
       %Route{
         gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
@@ -337,6 +348,39 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
           "#{Faker.Address.street_name()}::#{gtfs_prefix()}:#{Faker.Internet.slug()}"
         end
       )
+    end
+
+    def mbta_bus_leg_factory(attrs) do
+      agency = build(:agency, %{name: "MBTA"})
+      trip_gtfs_id = gtfs_prefix(agency.name) <> Faker.Internet.slug()
+
+      build(:leg, %{
+        agency: agency,
+        from:
+          build(:place, %{
+            stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
+          }),
+        intermediate_stops:
+          build_list(3, :stop, %{
+            gtfs_id: fn ->
+              sequence(:intermediate_stop_id, fn _ ->
+                gtfs_prefix(agency.name) <> Faker.Internet.slug()
+              end)
+            end
+          }),
+        mode: Faker.Util.pick([:TRANSIT, :RAIL, :SUBWAY, :BUS]),
+        real_time: true,
+        realtime_state: Faker.Util.pick(Leg.realtime_state()),
+        route: build(:route, type: 3),
+        to:
+          build(:place, %{
+            stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
+          }),
+        trip: build(:trip, %{gtfs_id: trip_gtfs_id}),
+        transit_leg: true
+      })
+      |> merge_attributes(attrs)
+      |> evaluate_lazy_attributes()
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -382,5 +382,37 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
       |> merge_attributes(attrs)
       |> evaluate_lazy_attributes()
     end
+
+    @doc """
+    Returns a list of itineraries that can be grouped.
+
+    You can pass in the number of groups you want and the number of itineraries in each group.
+    """
+    def groupable_otp_itineraries(group_count \\ 2, itinerary_count \\ 1) do
+      Enum.map(1..group_count, fn _ ->
+        otp_itineraries(itinerary_count)
+      end)
+      |> List.flatten()
+      |> Enum.shuffle()
+    end
+
+    # Create a number of otp itineraries with the same two random legs.
+    defp otp_itineraries(itinerary_count) do
+      [a, b, c] = build_list(3, :place_with_stop)
+      a_b_leg = build(:transit_leg, from: a, to: b)
+      b_c_leg = build(:transit_leg, from: b, to: c)
+      build_list(itinerary_count, :itinerary, legs: [a_b_leg, b_c_leg])
+    end
+
+    def itinerary_group_factory(attrs) do
+      itineraries = attrs[:itineraries] || build_list(5, :itinerary)
+      index = attrs[:representative_index] || Faker.random_between(0, Enum.count(itineraries) - 1)
+
+      %OpenTripPlannerClient.ItineraryGroup{
+        itineraries: itineraries,
+        representative_index: index,
+        time_key: attrs[:time_key] || Faker.Util.pick([:start, :end])
+      }
+    end
   end
 end


### PR DESCRIPTION
> [!IMPORTANT]
> This doesn't change the interface or output of `OpenTripPlannerClient.plan/1` yet, so current consumers will experience no change.

This PR brings in the itinerary grouping functionality currently exclusive to Dotcom. For reference:
- [`Dotcom.TripPlan.ItineraryGroup`](https://github.com/mbta/dotcom/blob/main/lib/dotcom/trip_plan/itinerary_group.ex)
- [`Dotcom.TripPlan.ItineraryGroups`](https://github.com/mbta/dotcom/blob/main/lib/dotcom/trip_plan/itinerary_groups.ex)

The bulk of that logic has been merged into a single `OpenTripPlannerClient.ItineraryGroup` module and I've written unit tests covering ~97%.

As a data structure, `%OpenTripPlannerClient.ItineraryGroup{}` is simpler than `%Dotcom.TripPlan.ItineraryGroup{}`, and various bits of information that'd been attached to a `%Dotcom.TripPlan.ItineraryGroup{}` are now available via a dedicated function in `OpenTripPlannerClient.ItineraryGroup`. I'm not so attached to that approach, but it did feel much easier to test out piece by piece. :)

Other differences:
- `OpenTripPlannerClient.ItineraryGroup` does not note fares like its Dotcom version did, this is because fare information still lives in Dotcom for now.
- Don't bother hashing the legs before grouping, the tuple itself is _enough_

Since there's a bunch of copy-pasting going on, feel free to point out mistakes of that vein too.

