### PR TITLE
refactor: Split `Parser.valid_plan/1` into two separate functions

### DIFF
--- a/lib/open_trip_planner_client/parser.ex
+++ b/lib/open_trip_planner_client/parser.ex
@@ -43,25 +43,12 @@ defmodule OpenTripPlannerClient.Parser do
     end
   end
 
-  defp plan_from_data(%{data: %{plan: nil}}) do
-    {:error, :no_plan}
-  end
+  defp plan_from_data(%{data: %{plan: nil}}), do: {:error, :no_plan}
+  defp plan_from_data(%{data: %{plan: plan}}), do: {:ok, plan}
+  defp plan_from_data(_), do: {:error, :no_data}
 
-  defp plan_from_data(%{data: %{plan: plan}}) do
-    {:ok, plan}
-  end
-
-  defp plan_from_data(_) do
-    {:error, :no_data}
-  end
-
-  defp validate_no_routing_errors(%Plan{routing_errors: []} = plan) do
-    {:ok, plan}
-  end
-
-  defp validate_no_routing_errors(%Plan{} = plan) do
-    {:error, Error.from_routing_errors(plan)}
-  end
+  defp validate_no_routing_errors(%Plan{routing_errors: []} = plan), do: {:ok, plan}
+  defp validate_no_routing_errors(%Plan{} = plan), do: {:error, Error.from_routing_errors(plan)}
 
   defp drop_nonfatal_errors(plan) do
     plan.routing_errors

--- a/test/open_trip_planner_client/parser_test.exs
+++ b/test/open_trip_planner_client/parser_test.exs
@@ -130,5 +130,23 @@ defmodule OpenTripPlannerClient.ParserTest do
                  data: %{plan: %{routing_errors: [%{code: "WALKING_BETTER_THAN_TRANSIT"}]}}
                })
     end
+
+    test "handles a nil plan" do
+      assert {{:error, :no_plan}, _log} =
+               with_log(fn ->
+                 validate_body(%{
+                   data: %{plan: nil}
+                 })
+               end)
+    end
+
+    test "handles a missing plan" do
+      assert {{:error, :no_data}, _log} =
+               with_log(fn ->
+                 validate_body(%{
+                   data: %{}
+                 })
+               end)
+    end
   end
 end


### PR DESCRIPTION
The prior version of `valid_plan/1` was being called twice, with two different types of arguments. Turns out - that function was really two different validation functions masquerading as one - one that validates the existence of a `plan` at all, and one that ensures that the plan doesn't have any fatal routing errors.

This PR clarifies that by splitting `valid_plan/1` up into two functions, `plan_from_data/1` and `validate_no_routing_errors/1`.