### PR TITLE
feat(OpenTripPlanner.Schema): add more fields to several resources

### DIFF
--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -10,7 +10,17 @@ defmodule OpenTripPlannerClient.Schema.Leg do
   use OpenTripPlannerClient.Schema
 
   alias OpenTripPlannerClient.PlanParams
-  alias OpenTripPlannerClient.Schema.{Agency, Geometry, LegTime, Place, Route, Step, Stop, Trip}
+
+  alias OpenTripPlannerClient.Schema.{
+    Agency,
+    Geometry,
+    IntermediateStop,
+    LegTime,
+    Place,
+    Route,
+    Step,
+    Trip
+  }
 
   @realtime_state [
     :SCHEDULED,
@@ -64,7 +74,7 @@ defmodule OpenTripPlannerClient.Schema.Leg do
              agency: Agency,
              end: LegTime,
              from: Place,
-             intermediate_stops: [Stop],
+             intermediate_stops: [IntermediateStop],
              leg_geometry: Geometry,
              mode: &__MODULE__.to_atom/1,
              realtime_state: &__MODULE__.to_atom/1,
@@ -81,7 +91,7 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     field(:end, LegTime.t(), @nonnull_field)
     field(:from, Place.t(), @nonnull_field)
     field(:headsign, String.t())
-    field(:intermediate_stops, [Stop.t()])
+    field(:intermediate_stops, [IntermediateStop.t()])
     field(:leg_geometry, Geometry.t())
     field(:mode, PlanParams.mode_t())
     field(:real_time, boolean())

--- a/lib/open_trip_planner_client/schema/route.ex
+++ b/lib/open_trip_planner_client/schema/route.ex
@@ -11,6 +11,9 @@ defmodule OpenTripPlannerClient.Schema.Route do
 
   use OpenTripPlannerClient.Schema
 
+  alias OpenTripPlannerClient.PlanParams
+  alias OpenTripPlannerClient.Schema.Agency
+
   @typedoc """
   Short name of the route, e.g. SL4
   """
@@ -45,7 +48,7 @@ defmodule OpenTripPlannerClient.Schema.Route do
   """
   @type hex_color :: String.t()
 
-  @derive Nestru.Decoder
+  @derive {Nestru.Decoder, hint: %{agency: Agency, mode: &__MODULE__.to_atom/1}}
   schema do
     field(:gtfs_id, gtfs_id(), @nonnull_field)
     field(:short_name, short_name())
@@ -55,8 +58,16 @@ defmodule OpenTripPlannerClient.Schema.Route do
     field(:text_color, hex_color())
     field(:desc, desc())
     field(:sort_order, non_neg_integer())
+    field(:mode, PlanParams.mode_t())
+    field(:agency, Agency.t())
   end
 
   @spec gtfs_route_type :: [gtfs_route_type()]
   def gtfs_route_type, do: @gtfs_route_type
+
+  @spec to_atom(any()) :: {:ok, any()}
+  def to_atom(string) when is_binary(string),
+    do: {:ok, OpenTripPlannerClient.Util.to_existing_atom(string)}
+
+  def to_atom(other), do: {:ok, other}
 end

--- a/lib/open_trip_planner_client/schema/stop.ex
+++ b/lib/open_trip_planner_client/schema/stop.ex
@@ -12,5 +12,6 @@ defmodule OpenTripPlannerClient.Schema.Stop do
   schema do
     field(:gtfs_id, gtfs_id(), @nonnull_field)
     field(:name, String.t())
+    field(:zone_id, String.t())
   end
 end

--- a/lib/open_trip_planner_client/schema/stop.ex
+++ b/lib/open_trip_planner_client/schema/stop.ex
@@ -1,9 +1,69 @@
 defmodule OpenTripPlannerClient.Schema.Stop do
   @moduledoc """
-  Trip is a specific occurance of a pattern, usually identified by route,
-  direction on the route and exact departure time.
+  Stop can represent either a single public transport stop, where passengers can board and/or disembark vehicles, or a station, which contains multiple stops.
 
-  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/Trip
+  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/Stop
+  """
+
+  use OpenTripPlannerClient.Schema
+
+  alias OpenTripPlannerClient.PlanParams
+  alias OpenTripPlannerClient.Schema.ParentStop
+
+  @typedoc "Transport mode (e.g. BUS) used by routes which pass through this stop"
+  @type vehicle_mode :: PlanParams.mode_t()
+
+  @wheelchair_boarding [:NOT_POSSIBLE, :NO_INFORMATION, :POSSIBLE]
+
+  @typedoc """
+  Whether wheelchair boarding is possible for at least some of vehicles on this stop
+  """
+  @type wheelchair_boarding ::
+          unquote(
+            @wheelchair_boarding
+            |> Enum.map_join(" | ", &inspect/1)
+            |> Code.string_to_quoted!()
+          )
+
+  @typedoc "ID of the zone where this stop is located"
+  @type zone_id :: String.t()
+
+  defimpl Nestru.PreDecoder do
+    # credo:disable-for-next-line
+    def gather_fields_for_decoding(_, _, map) do
+      updated_map =
+        map
+        |> update_in([:wheelchair_boarding], &OpenTripPlannerClient.Util.to_uppercase_atom/1)
+
+      {:ok, updated_map}
+    end
+  end
+
+  @derive {Nestru.Decoder,
+           hint: %{
+             parent_station: ParentStop,
+             wheelchair_boarding: &__MODULE__.to_atom/1
+           }}
+  schema do
+    field(:gtfs_id, gtfs_id(), @nonnull_field)
+    field(:name, String.t())
+    field(:url, String.t())
+    field(:vehicle_mode, PlanParams.mode_t())
+    field(:wheelchair_boarding, wheelchair_boarding())
+    field(:zone_id, zone_id())
+    field(:parent_station, ParentStop.t())
+  end
+
+  @spec wheelchair_boarding :: [wheelchair_boarding()]
+  def wheelchair_boarding, do: @wheelchair_boarding
+
+  @spec to_atom(any()) :: {:ok, any()}
+  def to_atom(term), do: {:ok, OpenTripPlannerClient.Util.to_uppercase_atom(term)}
+end
+
+defmodule OpenTripPlannerClient.Schema.ParentStop do
+  @moduledoc """
+  A subset of fields for `OpenTripPlannerClient.Schema.Stop`
   """
 
   use OpenTripPlannerClient.Schema
@@ -11,7 +71,18 @@ defmodule OpenTripPlannerClient.Schema.Stop do
   @derive Nestru.Decoder
   schema do
     field(:gtfs_id, gtfs_id(), @nonnull_field)
+  end
+end
+
+defmodule OpenTripPlannerClient.Schema.IntermediateStop do
+  @moduledoc """
+  A subset of fields for `OpenTripPlannerClient.Schema.Stop`
+  """
+
+  use OpenTripPlannerClient.Schema
+
+  @derive Nestru.Decoder
+  schema do
     field(:name, String.t())
-    field(:zone_id, String.t())
   end
 end

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -58,6 +58,7 @@ query TripPlan(
         realTime
         realtimeState
         route { 
+          agency { name }
           gtfsId
           shortName
           longName
@@ -66,6 +67,7 @@ query TripPlan(
           textColor
           desc
           sortOrder
+          mode
         }
         start { ...TimeInfo }
         steps {

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -94,7 +94,17 @@ fragment PlaceInfo on Place {
   name
   lat
   lon
-  stop { gtfsId, name, zoneId }
+  stop { 
+    gtfsId, 
+    name
+    url
+    vehicleMode
+    wheelchairBoarding
+    zoneId
+    parentStation {
+      gtfsId
+    }
+  }
 }
 
 fragment TimeInfo on LegTime {

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -94,7 +94,7 @@ fragment PlaceInfo on Place {
   name
   lat
   lon
-  stop { gtfsId, name }
+  stop { gtfsId, name, zoneId }
 }
 
 fragment TimeInfo on LegTime {

--- a/test/fixture/alewife_to_franklin_park_zoo.json
+++ b/test/fixture/alewife_to_franklin_park_zoo.json
@@ -1,37 +1,44 @@
 {
   "data": {
     "plan": {
-      "date": "2025-04-16T11:19:00.000-04:00",
+      "date": "2025-04-21T13:19:00.000-04:00",
       "itineraries": [
         {
-          "start": "2025-04-16T11:19:09-04:00",
-          "end": "2025-04-16T12:16:32-04:00",
-          "duration": 3443,
+          "start": "2025-04-21T13:31:00-04:00",
+          "end": "2025-04-21T14:29:50-04:00",
+          "duration": 3530,
           "walk_distance": 809.28,
           "number_of_transfers": 2,
           "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:02:00-04:00",
+                "scheduled_time": "2025-04-21T13:30:00-04:00",
                 "estimated": {
-                  "time": "2025-04-16T11:19:09-04:00",
-                  "delay": "PT17M9S"
+                  "time": "2025-04-21T13:31:00-04:00",
+                  "delay": "PT1M"
                 }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-04-16T11:21:00-04:00",
+                "scheduled_time": "2025-04-21T13:49:00-04:00",
                 "estimated": {
-                  "time": "2025-04-16T11:36:47-04:00",
-                  "delay": "PT15M47S"
+                  "time": "2025-04-21T13:49:31-04:00",
+                  "delay": "PT31S"
                 }
               },
               "to": {
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
@@ -40,41 +47,41 @@
                 "name": "Alewife",
                 "stop": {
                   "name": "Alewife",
-                  "gtfs_id": "mbta-ma-us:70061"
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  }
                 },
                 "lat": 42.396148,
                 "lon": -71.140698
               },
-              "duration": 1058.0,
+              "duration": 1111.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Davis",
-                  "gtfs_id": "mbta-ma-us:70063"
+                  "name": "Davis"
                 },
                 {
-                  "name": "Porter",
-                  "gtfs_id": "mbta-ma-us:70065"
+                  "name": "Porter"
                 },
                 {
-                  "name": "Harvard",
-                  "gtfs_id": "mbta-ma-us:70067"
+                  "name": "Harvard"
                 },
                 {
-                  "name": "Central",
-                  "gtfs_id": "mbta-ma-us:70069"
+                  "name": "Central"
                 },
                 {
-                  "name": "Kendall/MIT",
-                  "gtfs_id": "mbta-ma-us:70071"
+                  "name": "Kendall/MIT"
                 },
                 {
-                  "name": "Charles/MGH",
-                  "gtfs_id": "mbta-ma-us:70073"
+                  "name": "Charles/MGH"
                 },
                 {
-                  "name": "Park Street",
-                  "gtfs_id": "mbta-ma-us:70075"
+                  "name": "Park Street"
                 }
               ],
               "steps": [],
@@ -87,16 +94,20 @@
               },
               "route": {
                 "type": 1,
+                "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
                 "gtfs_id": "mbta-ma-us:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": null,
                 "long_name": "Red Line",
                 "text_color": "FFFFFF",
                 "sort_order": 10010
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:67994907",
+                "gtfs_id": "mbta-ma-us:67994933",
                 "direction_id": "0",
                 "trip_headsign": "Braintree",
                 "trip_short_name": null
@@ -108,19 +119,26 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:36:47-04:00",
+                "scheduled_time": "2025-04-21T13:49:31-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T11:38:34-04:00",
+                "scheduled_time": "2025-04-21T13:51:18-04:00",
                 "estimated": null
               },
               "to": {
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70020"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
@@ -129,7 +147,14 @@
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
@@ -177,19 +202,32 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:44:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T13:56:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T13:55:51-04:00",
+                  "delay": "-PT9S"
+                }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-04-16T11:56:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T14:08:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:06:24-04:00",
+                  "delay": "-PT1M36S"
+                }
               },
               "to": {
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us:70006"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:70006",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323132,
                 "lon": -71.099592
@@ -198,37 +236,38 @@
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70020"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 720.0,
+              "duration": 633.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Chinatown",
-                  "gtfs_id": "mbta-ma-us:70018"
+                  "name": "Chinatown"
                 },
                 {
-                  "name": "Tufts Medical Center",
-                  "gtfs_id": "mbta-ma-us:70016"
+                  "name": "Tufts Medical Center"
                 },
                 {
-                  "name": "Back Bay",
-                  "gtfs_id": "mbta-ma-us:70014"
+                  "name": "Back Bay"
                 },
                 {
-                  "name": "Massachusetts Avenue",
-                  "gtfs_id": "mbta-ma-us:70012"
+                  "name": "Massachusetts Avenue"
                 },
                 {
-                  "name": "Ruggles",
-                  "gtfs_id": "mbta-ma-us:70010"
+                  "name": "Ruggles"
                 },
                 {
-                  "name": "Roxbury Crossing",
-                  "gtfs_id": "mbta-ma-us:70008"
+                  "name": "Roxbury Crossing"
                 }
               ],
               "steps": [],
@@ -241,40 +280,51 @@
               },
               "route": {
                 "type": 1,
+                "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "ED8B00",
                 "gtfs_id": "mbta-ma-us:Orange",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": null,
                 "long_name": "Orange Line",
                 "text_color": "FFFFFF",
                 "sort_order": 10020
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:68078646",
+                "gtfs_id": "mbta-ma-us:68078600",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills",
                 "trip_short_name": null
               },
               "distance": 5215.25,
               "headsign": "Forest Hills",
-              "real_time": false,
+              "real_time": true,
               "transit_leg": true
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:56:00-04:00",
+                "scheduled_time": "2025-04-21T14:06:24-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T11:57:01-04:00",
+                "scheduled_time": "2025-04-21T14:07:25-04:00",
                 "estimated": null
               },
               "to": {
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:11531"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:11531",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323074,
                 "lon": -71.099546
@@ -283,7 +333,14 @@
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us:70006"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:70006",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323132,
                 "lon": -71.099592
@@ -317,18 +374,6 @@
                   "street_name": "Exit to buses, Centre Street"
                 },
                 {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "Jackson Square - Centre St, Busway, Park"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "ENTER_STATION",
-                  "street_name": "Jackson Square - Centre St, Busway, Park"
-                },
-                {
                   "distance": 12.19,
                   "absolute_direction": "EAST",
                   "relative_direction": "FOLLOW_SIGNS",
@@ -338,7 +383,7 @@
               "agency": null,
               "leg_geometry": {
                 "length": null,
-                "points": "qfiaGns}pL????????Vv@DMELKaA"
+                "points": "qfiaGns}pL????????Vv@KaA"
               },
               "route": null,
               "trip": null,
@@ -349,19 +394,30 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T12:00:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T14:12:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:11:53-04:00",
+                  "delay": "-PT7S"
+                }
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-04-16T12:08:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T14:19:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:21:18-04:00",
+                  "delay": "PT2M18S"
+                }
               },
               "to": {
                 "name": "Seaver St opp Elm Hill Ave",
                 "stop": {
                   "name": "Seaver St opp Elm Hill Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17401"
+                  "url": "https://www.mbta.com/stops/17401",
+                  "gtfs_id": "mbta-ma-us:17401",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
                 },
                 "lat": 42.307515,
                 "lon": -71.089263
@@ -370,37 +426,38 @@
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:11531"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:11531",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323074,
                 "lon": -71.099546
               },
-              "duration": 480.0,
+              "duration": 565.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Columbus Ave @ Dimock St",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:1265"
+                  "name": "Columbus Ave @ Dimock St"
                 },
                 {
-                  "name": "Columbus Ave opp Bray St",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:1266"
+                  "name": "Columbus Ave opp Bray St"
                 },
                 {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:10413"
+                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
                 },
                 {
-                  "name": "Columbus Ave @ Walnut Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:11413"
+                  "name": "Columbus Ave @ Walnut Ave"
                 },
                 {
-                  "name": "Seaver St opp Harold St",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17421"
+                  "name": "Seaver St opp Harold St"
                 },
                 {
-                  "name": "Seaver St opp Humboldt Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17411"
+                  "name": "Seaver St opp Humboldt Ave"
                 }
               ],
               "steps": [],
@@ -413,33 +470,37 @@
               },
               "route": {
                 "type": 3,
+                "mode": "BUS",
                 "desc": "Frequent Bus",
                 "color": "FFC72C",
-                "gtfs_id": "mbta-ma-us-no-disruptions:22",
+                "gtfs_id": "mbta-ma-us:22",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": "22",
                 "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
                 "text_color": "000000",
                 "sort_order": 50220
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-no-disruptions:68166929",
+                "gtfs_id": "mbta-ma-us:68394538",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
               },
               "distance": 2101.86,
               "headsign": "Ashmont",
-              "real_time": false,
+              "real_time": true,
               "transit_leg": true
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T12:08:00-04:00",
+                "scheduled_time": "2025-04-21T14:21:18-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T12:16:32-04:00",
+                "scheduled_time": "2025-04-21T14:29:50-04:00",
                 "estimated": null
               },
               "to": {
@@ -452,7 +513,12 @@
                 "name": "Seaver St opp Elm Hill Ave",
                 "stop": {
                   "name": "Seaver St opp Elm Hill Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17401"
+                  "url": "https://www.mbta.com/stops/17401",
+                  "gtfs_id": "mbta-ma-us:17401",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
                 },
                 "lat": 42.307515,
                 "lon": -71.089263
@@ -519,437 +585,41 @@
           ]
         },
         {
-          "start": "2025-04-16T11:19:09-04:00",
-          "end": "2025-04-16T12:19:12-04:00",
-          "duration": 3603,
-          "walk_distance": 1657.33,
-          "number_of_transfers": 1,
-          "accessibility_score": null,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T11:02:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T11:19:09-04:00",
-                  "delay": "PT17M9S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-04-16T11:23:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T11:38:11-04:00",
-                  "delay": "PT15M11S"
-                }
-              },
-              "to": {
-                "name": "South Station",
-                "stop": {
-                  "name": "South Station",
-                  "gtfs_id": "mbta-ma-us:70079"
-                },
-                "lat": 42.352271,
-                "lon": -71.055242
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "gtfs_id": "mbta-ma-us:70061"
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1142.0,
-              "realtime_state": null,
-              "intermediate_stops": [
-                {
-                  "name": "Davis",
-                  "gtfs_id": "mbta-ma-us:70063"
-                },
-                {
-                  "name": "Porter",
-                  "gtfs_id": "mbta-ma-us:70065"
-                },
-                {
-                  "name": "Harvard",
-                  "gtfs_id": "mbta-ma-us:70067"
-                },
-                {
-                  "name": "Central",
-                  "gtfs_id": "mbta-ma-us:70069"
-                },
-                {
-                  "name": "Kendall/MIT",
-                  "gtfs_id": "mbta-ma-us:70071"
-                },
-                {
-                  "name": "Charles/MGH",
-                  "gtfs_id": "mbta-ma-us:70073"
-                },
-                {
-                  "name": "Park Street",
-                  "gtfs_id": "mbta-ma-us:70075"
-                },
-                {
-                  "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
-                }
-              ],
-              "steps": [],
-              "agency": {
-                "name": "MBTA"
-              },
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHnB\\tAP|@J^@JCBC??HIHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS"
-              },
-              "route": {
-                "type": 1,
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "gtfs_id": "mbta-ma-us:Red",
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF",
-                "sort_order": 10010
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us:67994907",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 10360.26,
-              "headsign": "Braintree",
-              "real_time": true,
-              "transit_leg": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T11:38:11-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-04-16T11:41:58-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "South Station",
-                "stop": {
-                  "name": "South Station",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:NEC-2287"
-                },
-                "lat": 42.35141,
-                "lon": -71.055417
-              },
-              "from": {
-                "name": "South Station",
-                "stop": {
-                  "name": "South Station",
-                  "gtfs_id": "mbta-ma-us:70079"
-                },
-                "lat": 42.352271,
-                "lon": -71.055242
-              },
-              "duration": 227.0,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 47.85,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Silver Line - SL4 Nubian, lobby, Amtrak, Commuter Rail"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit-only gates"
-                },
-                {
-                  "distance": 6.1,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Bus Terminal, lobby, Amtrak, Silver Line - SL4 Nubian, Commuter Rail"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit"
-                },
-                {
-                  "distance": 13.41,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Summer Street, Atlantic Avenue, Amtrak, Commuter Rail"
-                },
-                {
-                  "distance": 17.38,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Bus Terminal, Summer Street, Atlantic Avenue, Commuter Rail, Amtrak"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "WEST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "South Station - Summer St, Atlantic Ave, Commuter Rail"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "ENTER_STATION",
-                  "street_name": "South Station - Summer St, Atlantic Ave, Commuter Rail"
-                },
-                {
-                  "distance": 17.38,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Red Line, Silver Line - SL1/SL2/SL3"
-                },
-                {
-                  "distance": 23.77,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Silver Line Nubian / Bus Terminal / Commuter Rail"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Commuter Rail, concourse"
-                },
-                {
-                  "distance": 23.77,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Commuter Rail, concourse"
-                },
-                {
-                  "distance": 127.66,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Commuter Rail - All trains"
-                }
-              ],
-              "agency": null,
-              "leg_geometry": {
-                "length": null,
-                "points": "u|naGh~tpL??????????Qa@????P`@??????jD`@"
-              },
-              "route": null,
-              "trip": null,
-              "distance": 277.34,
-              "headsign": null,
-              "real_time": false,
-              "transit_leg": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T11:47:00-04:00",
-                "estimated": null
-              },
-              "mode": "RAIL",
-              "end": {
-                "scheduled_time": "2025-04-16T12:00:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Four Corners/Geneva",
-                "stop": {
-                  "name": "Four Corners/Geneva",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:DB-2249-01"
-                },
-                "lat": 42.303955,
-                "lon": -71.077979
-              },
-              "from": {
-                "name": "South Station",
-                "stop": {
-                  "name": "South Station",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:NEC-2287"
-                },
-                "lat": 42.35141,
-                "lon": -71.055417
-              },
-              "duration": 780.0,
-              "realtime_state": null,
-              "intermediate_stops": [
-                {
-                  "name": "Newmarket",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:DB-2265-01"
-                },
-                {
-                  "name": "Uphams Corner",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:DB-2258-01"
-                }
-              ],
-              "steps": [],
-              "agency": {
-                "name": "MBTA"
-              },
-              "leg_geometry": {
-                "length": null,
-                "points": "kvnaGd|tpL|KxEr@XpDbBl@Zh@\\t@^hAp@fBfAvDzBvEnCFFHDJHjBdApAv@tAf@p@Nj@NLDPFR@b@@V?~@Av@A`AAhAAnDK|DGdHMxBEXDp@N`@Nh@XrAt@|A~@NJlE|BhBfAlAl@zAx@n@Z`@Rb@Rz@f@`@TbB~@f@T|@j@jCtAhFtCfCtA`B|@??nCxApAp@JFXL|B`AtAd@dAVnAVpAVtBZdATjGfAbANpEv@rARdCb@??HBfANXD`Et@F@`BZxA\\v@ThA^`Ab@tAh@fGbC~Al@PFFBZJtAh@fBt@`A^`C`AtCfAfA^~@`@bA`@\\LdChA|@f@v@d@`At@~@|@v@z@z@dAjBxBbCvCxA`Bx@bAr@t@v@v@v@l@FDLH"
-              },
-              "route": {
-                "type": 2,
-                "desc": "Regional Rail",
-                "color": "80276C",
-                "gtfs_id": "mbta-ma-us-no-disruptions:CR-Fairmount",
-                "short_name": null,
-                "long_name": "Fairmount Line",
-                "text_color": "FFFFFF",
-                "sort_order": 20001
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-no-disruptions:SPRING2025V2-715694-1637",
-                "direction_id": "0",
-                "trip_headsign": "Fairmount",
-                "trip_short_name": "1637"
-              },
-              "distance": 5686.15,
-              "headsign": "Fairmount",
-              "real_time": false,
-              "transit_leg": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T12:00:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-04-16T12:19:12-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Four Corners/Geneva",
-                "stop": {
-                  "name": "Four Corners/Geneva",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:DB-2249-01"
-                },
-                "lat": 42.303955,
-                "lon": -71.077979
-              },
-              "duration": 1152.0,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 88.76,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Track 1 (Outbound)"
-                },
-                {
-                  "distance": 40.6,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "SLIGHTLY_RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 3.74,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Washington Street"
-                },
-                {
-                  "distance": 223.95,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "Erie Street"
-                },
-                {
-                  "distance": 230.13,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "Hewins Street"
-                },
-                {
-                  "distance": 206.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Columbia Road"
-                },
-                {
-                  "distance": 109.03,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Franklin Park Road"
-                },
-                {
-                  "distance": 54.97,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "agency": null,
-              "leg_geometry": {
-                "length": null,
-                "points": "ypeaGnjypLdCpB?BTt@HGHJDCPJRPNRVp@ZpAp@|Bx@lCq@fA_BpCaAbBy@rAGLNXJ`@FP??DPBRBLBP@N?N@P?RA^@R?H?P?T?V@\\?f@@\\?HAHAFCFDLBD@D@Bv@`Bf@`AHPSRm@t@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "route": null,
-              "trip": null,
-              "distance": 1379.99,
-              "headsign": null,
-              "real_time": false,
-              "transit_leg": false
-            }
-          ]
-        },
-        {
-          "start": "2025-04-16T11:19:09-04:00",
-          "end": "2025-04-16T12:21:57-04:00",
-          "duration": 3768,
+          "start": "2025-04-21T13:31:00-04:00",
+          "end": "2025-04-21T14:38:15-04:00",
+          "duration": 4035,
           "walk_distance": 576.69,
           "number_of_transfers": 1,
           "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:02:00-04:00",
+                "scheduled_time": "2025-04-21T13:30:00-04:00",
                 "estimated": {
-                  "time": "2025-04-16T11:19:09-04:00",
-                  "delay": "PT17M9S"
+                  "time": "2025-04-21T13:31:00-04:00",
+                  "delay": "PT1M"
                 }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-04-16T11:27:00-04:00",
+                "scheduled_time": "2025-04-21T13:55:00-04:00",
                 "estimated": {
-                  "time": "2025-04-16T11:42:44-04:00",
-                  "delay": "PT15M44S"
+                  "time": "2025-04-21T13:55:13-04:00",
+                  "delay": "PT13S"
                 }
               },
               "to": {
                 "name": "Andrew",
                 "stop": {
                   "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:70083"
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
                 },
                 "lat": 42.330154,
                 "lon": -71.057655
@@ -958,53 +628,50 @@
                 "name": "Alewife",
                 "stop": {
                   "name": "Alewife",
-                  "gtfs_id": "mbta-ma-us:70061"
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  }
                 },
                 "lat": 42.396148,
                 "lon": -71.140698
               },
-              "duration": 1415.0,
+              "duration": 1453.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Davis",
-                  "gtfs_id": "mbta-ma-us:70063"
+                  "name": "Davis"
                 },
                 {
-                  "name": "Porter",
-                  "gtfs_id": "mbta-ma-us:70065"
+                  "name": "Porter"
                 },
                 {
-                  "name": "Harvard",
-                  "gtfs_id": "mbta-ma-us:70067"
+                  "name": "Harvard"
                 },
                 {
-                  "name": "Central",
-                  "gtfs_id": "mbta-ma-us:70069"
+                  "name": "Central"
                 },
                 {
-                  "name": "Kendall/MIT",
-                  "gtfs_id": "mbta-ma-us:70071"
+                  "name": "Kendall/MIT"
                 },
                 {
-                  "name": "Charles/MGH",
-                  "gtfs_id": "mbta-ma-us:70073"
+                  "name": "Charles/MGH"
                 },
                 {
-                  "name": "Park Street",
-                  "gtfs_id": "mbta-ma-us:70075"
+                  "name": "Park Street"
                 },
                 {
-                  "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
+                  "name": "Downtown Crossing"
                 },
                 {
-                  "name": "South Station",
-                  "gtfs_id": "mbta-ma-us:70079"
+                  "name": "South Station"
                 },
                 {
-                  "name": "Broadway",
-                  "gtfs_id": "mbta-ma-us:70081"
+                  "name": "Broadway"
                 }
               ],
               "steps": [],
@@ -1017,16 +684,20 @@
               },
               "route": {
                 "type": 1,
+                "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
                 "gtfs_id": "mbta-ma-us:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": null,
                 "long_name": "Red Line",
                 "text_color": "FFFFFF",
                 "sort_order": 10010
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:67994907",
+                "gtfs_id": "mbta-ma-us:67994933",
                 "direction_id": "0",
                 "trip_headsign": "Braintree",
                 "trip_short_name": null
@@ -1038,19 +709,26 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:42:44-04:00",
+                "scheduled_time": "2025-04-21T13:55:13-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T11:43:33-04:00",
+                "scheduled_time": "2025-04-21T13:56:02-04:00",
                 "estimated": null
               },
               "to": {
                 "name": "Andrew",
                 "stop": {
                   "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:13"
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:13",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
                 },
                 "lat": 42.329962,
                 "lon": -71.057625
@@ -1059,7 +737,14 @@
                 "name": "Andrew",
                 "stop": {
                   "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:70083"
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
                 },
                 "lat": 42.330154,
                 "lon": -71.057655
@@ -1101,25 +786,30 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:51:00-04:00",
+                "scheduled_time": "2025-04-21T14:05:00-04:00",
                 "estimated": {
-                  "time": "2025-04-16T11:51:35-04:00",
-                  "delay": "PT35S"
+                  "time": "2025-04-21T14:02:08-04:00",
+                  "delay": "-PT2M52S"
                 }
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-04-16T12:17:00-04:00",
+                "scheduled_time": "2025-04-21T14:33:00-04:00",
                 "estimated": {
-                  "time": "2025-04-16T12:14:47-04:00",
-                  "delay": "-PT2M13S"
+                  "time": "2025-04-21T14:31:05-04:00",
+                  "delay": "-PT1M55S"
                 }
               },
               "to": {
                 "name": "Franklin Park Zoo @ Entrance",
                 "stop": {
                   "name": "Franklin Park Zoo @ Entrance",
-                  "gtfs_id": "mbta-ma-us:1587"
+                  "url": "https://www.mbta.com/stops/1587",
+                  "gtfs_id": "mbta-ma-us:1587",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "NO_INFORMATION",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
                 },
                 "lat": 42.303124,
                 "lon": -71.08595
@@ -1128,77 +818,68 @@
                 "name": "Andrew",
                 "stop": {
                   "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:13"
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:13",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
                 },
                 "lat": 42.329962,
                 "lon": -71.057625
               },
-              "duration": 1392.0,
+              "duration": 1737.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "South Bay Mall @ Target",
-                  "gtfs_id": "mbta-ma-us:11241"
+                  "name": "South Bay Mall @ Target"
                 },
                 {
-                  "name": "South Bay Mall opp Bed Bath & Beyond",
-                  "gtfs_id": "mbta-ma-us:11242"
+                  "name": "South Bay Mall opp Bed Bath & Beyond"
                 },
                 {
-                  "name": "South Bay Mall @ Allstate Rd",
-                  "gtfs_id": "mbta-ma-us:11244"
+                  "name": "South Bay Mall @ Allstate Rd"
                 },
                 {
-                  "name": "Massachusetts Ave opp Clapp St",
-                  "gtfs_id": "mbta-ma-us:133"
+                  "name": "Massachusetts Ave opp Clapp St"
                 },
                 {
-                  "name": "Massachusetts Ave @ Columbia Rd",
-                  "gtfs_id": "mbta-ma-us:134"
+                  "name": "Massachusetts Ave @ Columbia Rd"
                 },
                 {
-                  "name": "Columbia Rd @ Holden St",
-                  "gtfs_id": "mbta-ma-us:362"
+                  "name": "Columbia Rd @ Holden St"
                 },
                 {
-                  "name": "Columbia Rd @ Dudley St",
-                  "gtfs_id": "mbta-ma-us:2910"
+                  "name": "Columbia Rd @ Dudley St"
                 },
                 {
-                  "name": "Columbia Rd @ Bird St",
-                  "gtfs_id": "mbta-ma-us:2911"
+                  "name": "Columbia Rd @ Bird St"
                 },
                 {
-                  "name": "Columbia Rd @ Glendale St",
-                  "gtfs_id": "mbta-ma-us:2912"
+                  "name": "Columbia Rd @ Glendale St"
                 },
                 {
-                  "name": "Columbia Rd @ Quincy St",
-                  "gtfs_id": "mbta-ma-us:2913"
+                  "name": "Columbia Rd @ Quincy St"
                 },
                 {
-                  "name": "Columbia Rd @ Hamilton St",
-                  "gtfs_id": "mbta-ma-us:2914"
+                  "name": "Columbia Rd @ Hamilton St"
                 },
                 {
-                  "name": "Columbia Rd opp Wyola Pl",
-                  "gtfs_id": "mbta-ma-us:2915"
+                  "name": "Columbia Rd opp Wyola Pl"
                 },
                 {
-                  "name": "Columbia Rd @ Devon St",
-                  "gtfs_id": "mbta-ma-us:2916"
+                  "name": "Columbia Rd @ Devon St"
                 },
                 {
-                  "name": "Columbia Rd @ Geneva Ave",
-                  "gtfs_id": "mbta-ma-us:2918"
+                  "name": "Columbia Rd @ Geneva Ave"
                 },
                 {
-                  "name": "Columbia Rd @ Washington St",
-                  "gtfs_id": "mbta-ma-us:2919"
+                  "name": "Columbia Rd @ Washington St"
                 },
                 {
-                  "name": "Columbia Rd @ Seaver St",
-                  "gtfs_id": "mbta-ma-us:2920"
+                  "name": "Columbia Rd @ Seaver St"
                 }
               ],
               "steps": [],
@@ -1211,16 +892,20 @@
               },
               "route": {
                 "type": 3,
+                "mode": "BUS",
                 "desc": "Local Bus",
                 "color": "FFC72C",
                 "gtfs_id": "mbta-ma-us:16",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": "16",
                 "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
                 "text_color": "000000",
                 "sort_order": 50160
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:68166713",
+                "gtfs_id": "mbta-ma-us:68394132",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills via South Bay Center",
                 "trip_short_name": null
@@ -1232,12 +917,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T12:14:47-04:00",
+                "scheduled_time": "2025-04-21T14:31:05-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T12:21:57-04:00",
+                "scheduled_time": "2025-04-21T14:38:15-04:00",
                 "estimated": null
               },
               "to": {
@@ -1250,7 +935,12 @@
                 "name": "Franklin Park Zoo @ Entrance",
                 "stop": {
                   "name": "Franklin Park Zoo @ Entrance",
-                  "gtfs_id": "mbta-ma-us:1587"
+                  "url": "https://www.mbta.com/stops/1587",
+                  "gtfs_id": "mbta-ma-us:1587",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "NO_INFORMATION",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
                 },
                 "lat": 42.303124,
                 "lon": -71.08595
@@ -1299,468 +989,41 @@
           ]
         },
         {
-          "start": "2025-04-16T11:25:48-04:00",
-          "end": "2025-04-16T12:21:57-04:00",
-          "duration": 3369,
-          "walk_distance": 576.69,
-          "number_of_transfers": 2,
-          "accessibility_score": null,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T11:10:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T11:25:48-04:00",
-                  "delay": "PT15M48S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-04-16T11:35:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T11:49:10-04:00",
-                  "delay": "PT14M10S"
-                }
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:70083"
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "gtfs_id": "mbta-ma-us:70061"
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1402.0,
-              "realtime_state": null,
-              "intermediate_stops": [
-                {
-                  "name": "Davis",
-                  "gtfs_id": "mbta-ma-us:70063"
-                },
-                {
-                  "name": "Porter",
-                  "gtfs_id": "mbta-ma-us:70065"
-                },
-                {
-                  "name": "Harvard",
-                  "gtfs_id": "mbta-ma-us:70067"
-                },
-                {
-                  "name": "Central",
-                  "gtfs_id": "mbta-ma-us:70069"
-                },
-                {
-                  "name": "Kendall/MIT",
-                  "gtfs_id": "mbta-ma-us:70071"
-                },
-                {
-                  "name": "Charles/MGH",
-                  "gtfs_id": "mbta-ma-us:70073"
-                },
-                {
-                  "name": "Park Street",
-                  "gtfs_id": "mbta-ma-us:70075"
-                },
-                {
-                  "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
-                },
-                {
-                  "name": "South Station",
-                  "gtfs_id": "mbta-ma-us:70079"
-                },
-                {
-                  "name": "Broadway",
-                  "gtfs_id": "mbta-ma-us:70081"
-                }
-              ],
-              "steps": [],
-              "agency": {
-                "name": "MBTA"
-              },
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHnB\\tAP|@J^@JCBC??HIHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
-              },
-              "route": {
-                "type": 1,
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "gtfs_id": "mbta-ma-us:Red",
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF",
-                "sort_order": 10010
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us:67994913",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 13074.0,
-              "headsign": "Braintree",
-              "real_time": true,
-              "transit_leg": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T11:49:10-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-04-16T11:49:59-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:13"
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:70083"
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "duration": 49.0,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 20.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 23.89,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "agency": null,
-              "leg_geometry": {
-                "length": null,
-                "points": "mrjaGjmupL??\\h@Fo@"
-              },
-              "route": null,
-              "trip": null,
-              "distance": 56.2,
-              "headsign": null,
-              "real_time": false,
-              "transit_leg": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T11:55:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T11:55:00-04:00",
-                  "delay": "PT0S"
-                }
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-04-16T11:59:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T11:59:23-04:00",
-                  "delay": "PT23S"
-                }
-              },
-              "to": {
-                "name": "Columbia Rd @ Dudley St",
-                "stop": {
-                  "name": "Columbia Rd @ Dudley St",
-                  "gtfs_id": "mbta-ma-us:2910"
-                },
-                "lat": 42.317228,
-                "lon": -71.065045
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "gtfs_id": "mbta-ma-us:13"
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "duration": 263.0,
-              "realtime_state": null,
-              "intermediate_stops": [
-                {
-                  "name": "Boston St @ Ellery St",
-                  "gtfs_id": "mbta-ma-us:2905"
-                },
-                {
-                  "name": "Boston St opp Washburn St",
-                  "gtfs_id": "mbta-ma-us:2906"
-                },
-                {
-                  "name": "Boston St @ W Howell St",
-                  "gtfs_id": "mbta-ma-us:2907"
-                },
-                {
-                  "name": "Boston St opp Harvest St",
-                  "gtfs_id": "mbta-ma-us:2908"
-                },
-                {
-                  "name": "Boston St opp Mayhew St",
-                  "gtfs_id": "mbta-ma-us:2909"
-                },
-                {
-                  "name": "Columbia Rd @ Holden St",
-                  "gtfs_id": "mbta-ma-us:362"
-                }
-              ],
-              "steps": [],
-              "agency": {
-                "name": "MBTA"
-              },
-              "leg_geometry": {
-                "length": null,
-                "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@??RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J????lA\\\\LXJ??j@RVNRL`BfA~@l@????n@`@|@h@dAr@n@`@~@`@tA^XF????x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV"
-              },
-              "route": {
-                "type": 3,
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "gtfs_id": "mbta-ma-us:17",
-                "short_name": "17",
-                "long_name": "Fields Corner Station - Andrew Station",
-                "text_color": "000000",
-                "sort_order": 50170
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us:68167873",
-                "direction_id": "0",
-                "trip_headsign": "Fields Corner",
-                "trip_short_name": null
-              },
-              "distance": 1679.14,
-              "headsign": "Fields Corner",
-              "real_time": true,
-              "transit_leg": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T12:04:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T12:04:28-04:00",
-                  "delay": "PT28S"
-                }
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-04-16T12:17:00-04:00",
-                "estimated": {
-                  "time": "2025-04-16T12:14:47-04:00",
-                  "delay": "-PT2M13S"
-                }
-              },
-              "to": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "gtfs_id": "mbta-ma-us:1587"
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "from": {
-                "name": "Columbia Rd @ Dudley St",
-                "stop": {
-                  "name": "Columbia Rd @ Dudley St",
-                  "gtfs_id": "mbta-ma-us:2910"
-                },
-                "lat": 42.317228,
-                "lon": -71.065045
-              },
-              "duration": 619.0,
-              "realtime_state": null,
-              "intermediate_stops": [
-                {
-                  "name": "Columbia Rd @ Bird St",
-                  "gtfs_id": "mbta-ma-us:2911"
-                },
-                {
-                  "name": "Columbia Rd @ Glendale St",
-                  "gtfs_id": "mbta-ma-us:2912"
-                },
-                {
-                  "name": "Columbia Rd @ Quincy St",
-                  "gtfs_id": "mbta-ma-us:2913"
-                },
-                {
-                  "name": "Columbia Rd @ Hamilton St",
-                  "gtfs_id": "mbta-ma-us:2914"
-                },
-                {
-                  "name": "Columbia Rd opp Wyola Pl",
-                  "gtfs_id": "mbta-ma-us:2915"
-                },
-                {
-                  "name": "Columbia Rd @ Devon St",
-                  "gtfs_id": "mbta-ma-us:2916"
-                },
-                {
-                  "name": "Columbia Rd @ Geneva Ave",
-                  "gtfs_id": "mbta-ma-us:2918"
-                },
-                {
-                  "name": "Columbia Rd @ Washington St",
-                  "gtfs_id": "mbta-ma-us:2919"
-                },
-                {
-                  "name": "Columbia Rd @ Seaver St",
-                  "gtfs_id": "mbta-ma-us:2920"
-                }
-              ],
-              "steps": [],
-              "agency": {
-                "name": "MBTA"
-              },
-              "leg_geometry": {
-                "length": null,
-                "points": "gahaGd{vpL??Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
-              },
-              "route": {
-                "type": 3,
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "gtfs_id": "mbta-ma-us:16",
-                "short_name": "16",
-                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000",
-                "sort_order": 50160
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us:68166713",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills via South Bay Center",
-                "trip_short_name": null
-              },
-              "distance": 2411.37,
-              "headsign": "Forest Hills via South Bay Center",
-              "real_time": true,
-              "transit_leg": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-04-16T12:14:47-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-04-16T12:21:57-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "gtfs_id": "mbta-ma-us:1587"
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "duration": 430.0,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 43.54,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Franklin Park Road"
-                },
-                {
-                  "distance": 54.97,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "agency": null,
-              "leg_geometry": {
-                "length": null,
-                "points": "oieaGd~zpLFGf@`AHPSRm@t@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "route": null,
-              "trip": null,
-              "distance": 520.49,
-              "headsign": null,
-              "real_time": false,
-              "transit_leg": false
-            }
-          ]
-        },
-        {
-          "start": "2025-04-16T11:32:00-04:00",
-          "end": "2025-04-16T12:30:32-04:00",
-          "duration": 3512,
+          "start": "2025-04-21T13:46:00-04:00",
+          "end": "2025-04-21T14:42:32-04:00",
+          "duration": 3392,
           "walk_distance": 809.28,
           "number_of_transfers": 2,
           "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:32:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T13:45:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T13:46:00-04:00",
+                  "delay": "PT1M"
+                }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-04-16T11:51:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T14:04:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:04:31-04:00",
+                  "delay": "PT31S"
+                }
               },
               "to": {
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
@@ -1769,41 +1032,41 @@
                 "name": "Alewife",
                 "stop": {
                   "name": "Alewife",
-                  "gtfs_id": "mbta-ma-us:70061"
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  }
                 },
                 "lat": 42.396148,
                 "lon": -71.140698
               },
-              "duration": 1140.0,
+              "duration": 1111.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Davis",
-                  "gtfs_id": "mbta-ma-us:70063"
+                  "name": "Davis"
                 },
                 {
-                  "name": "Porter",
-                  "gtfs_id": "mbta-ma-us:70065"
+                  "name": "Porter"
                 },
                 {
-                  "name": "Harvard",
-                  "gtfs_id": "mbta-ma-us:70067"
+                  "name": "Harvard"
                 },
                 {
-                  "name": "Central",
-                  "gtfs_id": "mbta-ma-us:70069"
+                  "name": "Central"
                 },
                 {
-                  "name": "Kendall/MIT",
-                  "gtfs_id": "mbta-ma-us:70071"
+                  "name": "Kendall/MIT"
                 },
                 {
-                  "name": "Charles/MGH",
-                  "gtfs_id": "mbta-ma-us:70073"
+                  "name": "Charles/MGH"
                 },
                 {
-                  "name": "Park Street",
-                  "gtfs_id": "mbta-ma-us:70075"
+                  "name": "Park Street"
                 }
               ],
               "steps": [],
@@ -1816,40 +1079,51 @@
               },
               "route": {
                 "type": 1,
+                "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
                 "gtfs_id": "mbta-ma-us:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": null,
                 "long_name": "Red Line",
                 "text_color": "FFFFFF",
                 "sort_order": 10010
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:67994927",
+                "gtfs_id": "mbta-ma-us:67994941",
                 "direction_id": "0",
                 "trip_headsign": "Braintree",
                 "trip_short_name": null
               },
               "distance": 9820.78,
               "headsign": "Braintree",
-              "real_time": false,
+              "real_time": true,
               "transit_leg": true
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:51:00-04:00",
+                "scheduled_time": "2025-04-21T14:04:31-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T11:52:47-04:00",
+                "scheduled_time": "2025-04-21T14:06:18-04:00",
                 "estimated": null
               },
               "to": {
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70020"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
@@ -1858,7 +1132,14 @@
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70077"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
@@ -1906,19 +1187,32 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T11:58:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T14:10:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:09:51-04:00",
+                  "delay": "-PT9S"
+                }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-04-16T12:10:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-04-21T14:22:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:20:24-04:00",
+                  "delay": "-PT1M36S"
+                }
               },
               "to": {
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us:70006"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:70006",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323132,
                 "lon": -71.099592
@@ -1927,37 +1221,38 @@
                 "name": "Downtown Crossing",
                 "stop": {
                   "name": "Downtown Crossing",
-                  "gtfs_id": "mbta-ma-us:70020"
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
                 },
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 720.0,
+              "duration": 633.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Chinatown",
-                  "gtfs_id": "mbta-ma-us:70018"
+                  "name": "Chinatown"
                 },
                 {
-                  "name": "Tufts Medical Center",
-                  "gtfs_id": "mbta-ma-us:70016"
+                  "name": "Tufts Medical Center"
                 },
                 {
-                  "name": "Back Bay",
-                  "gtfs_id": "mbta-ma-us:70014"
+                  "name": "Back Bay"
                 },
                 {
-                  "name": "Massachusetts Avenue",
-                  "gtfs_id": "mbta-ma-us:70012"
+                  "name": "Massachusetts Avenue"
                 },
                 {
-                  "name": "Ruggles",
-                  "gtfs_id": "mbta-ma-us:70010"
+                  "name": "Ruggles"
                 },
                 {
-                  "name": "Roxbury Crossing",
-                  "gtfs_id": "mbta-ma-us:70008"
+                  "name": "Roxbury Crossing"
                 }
               ],
               "steps": [],
@@ -1970,40 +1265,51 @@
               },
               "route": {
                 "type": 1,
+                "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "ED8B00",
                 "gtfs_id": "mbta-ma-us:Orange",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": null,
                 "long_name": "Orange Line",
                 "text_color": "FFFFFF",
                 "sort_order": 10020
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:68078658",
+                "gtfs_id": "mbta-ma-us:68078616",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills",
                 "trip_short_name": null
               },
               "distance": 5215.25,
               "headsign": "Forest Hills",
-              "real_time": false,
+              "real_time": true,
               "transit_leg": true
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T12:10:00-04:00",
+                "scheduled_time": "2025-04-21T14:20:24-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T12:11:01-04:00",
+                "scheduled_time": "2025-04-21T14:21:25-04:00",
                 "estimated": null
               },
               "to": {
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:11531"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:11531",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323074,
                 "lon": -71.099546
@@ -2012,7 +1318,14 @@
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us:70006"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:70006",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323132,
                 "lon": -71.099592
@@ -2046,18 +1359,6 @@
                   "street_name": "Exit to buses, Centre Street"
                 },
                 {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "Jackson Square - Centre St, Busway, Park"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "ENTER_STATION",
-                  "street_name": "Jackson Square - Centre St, Busway, Park"
-                },
-                {
                   "distance": 12.19,
                   "absolute_direction": "EAST",
                   "relative_direction": "FOLLOW_SIGNS",
@@ -2067,7 +1368,7 @@
               "agency": null,
               "leg_geometry": {
                 "length": null,
-                "points": "qfiaGns}pL????????Vv@DMELKaA"
+                "points": "qfiaGns}pL????????Vv@KaA"
               },
               "route": null,
               "trip": null,
@@ -2078,19 +1379,24 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T12:14:00-04:00",
+                "scheduled_time": "2025-04-21T14:27:00-04:00",
                 "estimated": null
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-04-16T12:22:00-04:00",
+                "scheduled_time": "2025-04-21T14:34:00-04:00",
                 "estimated": null
               },
               "to": {
                 "name": "Seaver St opp Elm Hill Ave",
                 "stop": {
                   "name": "Seaver St opp Elm Hill Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17401"
+                  "url": "https://www.mbta.com/stops/17401",
+                  "gtfs_id": "mbta-ma-us:17401",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
                 },
                 "lat": 42.307515,
                 "lon": -71.089263
@@ -2099,37 +1405,38 @@
                 "name": "Jackson Square",
                 "stop": {
                   "name": "Jackson Square",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:11531"
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:11531",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
                 },
                 "lat": 42.323074,
                 "lon": -71.099546
               },
-              "duration": 480.0,
+              "duration": 420.0,
               "realtime_state": null,
               "intermediate_stops": [
                 {
-                  "name": "Columbus Ave @ Dimock St",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:1265"
+                  "name": "Columbus Ave @ Dimock St"
                 },
                 {
-                  "name": "Columbus Ave opp Bray St",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:1266"
+                  "name": "Columbus Ave opp Bray St"
                 },
                 {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:10413"
+                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
                 },
                 {
-                  "name": "Columbus Ave @ Walnut Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:11413"
+                  "name": "Columbus Ave @ Walnut Ave"
                 },
                 {
-                  "name": "Seaver St opp Harold St",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17421"
+                  "name": "Seaver St opp Harold St"
                 },
                 {
-                  "name": "Seaver St opp Humboldt Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17411"
+                  "name": "Seaver St opp Humboldt Ave"
                 }
               ],
               "steps": [],
@@ -2142,16 +1449,20 @@
               },
               "route": {
                 "type": 3,
+                "mode": "BUS",
                 "desc": "Frequent Bus",
                 "color": "FFC72C",
-                "gtfs_id": "mbta-ma-us-no-disruptions:22",
+                "gtfs_id": "mbta-ma-us:22",
+                "agency": {
+                  "name": "MBTA"
+                },
                 "short_name": "22",
                 "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
                 "text_color": "000000",
                 "sort_order": 50220
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-no-disruptions:68166926",
+                "gtfs_id": "mbta-ma-us:68394540",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
@@ -2163,12 +1474,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-04-16T12:22:00-04:00",
+                "scheduled_time": "2025-04-21T14:34:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-04-16T12:30:32-04:00",
+                "scheduled_time": "2025-04-21T14:42:32-04:00",
                 "estimated": null
               },
               "to": {
@@ -2181,7 +1492,985 @@
                 "name": "Seaver St opp Elm Hill Ave",
                 "stop": {
                   "name": "Seaver St opp Elm Hill Ave",
-                  "gtfs_id": "mbta-ma-us-no-disruptions:17401"
+                  "url": "https://www.mbta.com/stops/17401",
+                  "gtfs_id": "mbta-ma-us:17401",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.307515,
+                "lon": -71.089263
+              },
+              "duration": 512.0,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 244.74,
+                  "absolute_direction": "WEST",
+                  "relative_direction": "DEPART",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 42.5,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 57.09,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "SLIGHTLY_LEFT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 89.98,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "RIGHT",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 12.65,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 156.98,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 4.18,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                }
+              ],
+              "agency": null,
+              "leg_geometry": {
+                "length": null,
+                "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
+              },
+              "route": null,
+              "trip": null,
+              "distance": 608.11,
+              "headsign": null,
+              "real_time": false,
+              "transit_leg": false
+            }
+          ]
+        },
+        {
+          "start": "2025-04-21T13:46:00-04:00",
+          "end": "2025-04-21T14:45:55-04:00",
+          "duration": 3595,
+          "walk_distance": 576.69,
+          "number_of_transfers": 1,
+          "accessibility_score": null,
+          "legs": [
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T13:45:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T13:46:00-04:00",
+                  "delay": "PT1M"
+                }
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-04-21T14:10:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:10:13-04:00",
+                  "delay": "PT13S"
+                }
+              },
+              "to": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.330154,
+                "lon": -71.057655
+              },
+              "from": {
+                "name": "Alewife",
+                "stop": {
+                  "name": "Alewife",
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  }
+                },
+                "lat": 42.396148,
+                "lon": -71.140698
+              },
+              "duration": 1453.0,
+              "realtime_state": null,
+              "intermediate_stops": [
+                {
+                  "name": "Davis"
+                },
+                {
+                  "name": "Porter"
+                },
+                {
+                  "name": "Harvard"
+                },
+                {
+                  "name": "Central"
+                },
+                {
+                  "name": "Kendall/MIT"
+                },
+                {
+                  "name": "Charles/MGH"
+                },
+                {
+                  "name": "Park Street"
+                },
+                {
+                  "name": "Downtown Crossing"
+                },
+                {
+                  "name": "South Station"
+                },
+                {
+                  "name": "Broadway"
+                }
+              ],
+              "steps": [],
+              "agency": {
+                "name": "MBTA"
+              },
+              "leg_geometry": {
+                "length": null,
+                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHnB\\tAP|@J^@JCBC??HIHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
+              },
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "DA291C",
+                "gtfs_id": "mbta-ma-us:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Red Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10010
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:67994941",
+                "direction_id": "0",
+                "trip_headsign": "Braintree",
+                "trip_short_name": null
+              },
+              "distance": 13074.0,
+              "headsign": "Braintree",
+              "real_time": true,
+              "transit_leg": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:10:13-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-04-21T14:11:02-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:13",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.329962,
+                "lon": -71.057625
+              },
+              "from": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.330154,
+                "lon": -71.057655
+              },
+              "duration": 49.0,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 20.12,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to street and buses"
+                },
+                {
+                  "distance": 23.89,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Buses"
+                },
+                {
+                  "distance": 12.19,
+                  "absolute_direction": "EAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Buses"
+                }
+              ],
+              "agency": null,
+              "leg_geometry": {
+                "length": null,
+                "points": "mrjaGjmupL??\\h@Fo@"
+              },
+              "route": null,
+              "trip": null,
+              "distance": 56.2,
+              "headsign": null,
+              "real_time": false,
+              "transit_leg": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:20:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:16:26-04:00",
+                  "delay": "-PT3M34S"
+                }
+              },
+              "mode": "BUS",
+              "end": {
+                "scheduled_time": "2025-04-21T14:48:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:38:45-04:00",
+                  "delay": "-PT9M15S"
+                }
+              },
+              "to": {
+                "name": "Franklin Park Zoo @ Entrance",
+                "stop": {
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "url": "https://www.mbta.com/stops/1587",
+                  "gtfs_id": "mbta-ma-us:1587",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "NO_INFORMATION",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.303124,
+                "lon": -71.08595
+              },
+              "from": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:13",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.329962,
+                "lon": -71.057625
+              },
+              "duration": 1339.0,
+              "realtime_state": null,
+              "intermediate_stops": [
+                {
+                  "name": "South Bay Mall @ Target"
+                },
+                {
+                  "name": "South Bay Mall opp Bed Bath & Beyond"
+                },
+                {
+                  "name": "South Bay Mall @ Allstate Rd"
+                },
+                {
+                  "name": "Massachusetts Ave opp Clapp St"
+                },
+                {
+                  "name": "Massachusetts Ave @ Columbia Rd"
+                },
+                {
+                  "name": "Columbia Rd @ Holden St"
+                },
+                {
+                  "name": "Columbia Rd @ Dudley St"
+                },
+                {
+                  "name": "Columbia Rd @ Bird St"
+                },
+                {
+                  "name": "Columbia Rd @ Glendale St"
+                },
+                {
+                  "name": "Columbia Rd @ Quincy St"
+                },
+                {
+                  "name": "Columbia Rd @ Hamilton St"
+                },
+                {
+                  "name": "Columbia Rd opp Wyola Pl"
+                },
+                {
+                  "name": "Columbia Rd @ Devon St"
+                },
+                {
+                  "name": "Columbia Rd @ Geneva Ave"
+                },
+                {
+                  "name": "Columbia Rd @ Washington St"
+                },
+                {
+                  "name": "Columbia Rd @ Seaver St"
+                }
+              ],
+              "steps": [],
+              "agency": {
+                "name": "MBTA"
+              },
+              "leg_geometry": {
+                "length": null,
+                "points": "arjaGdmupL?cCd@An@?`@Jm@tFm@jECR[hDWnBQ~ASbBAFg@lEET?VJRHPb@FNCHIHEDKBQ?iAA[?????Y@e@Dg@FSFOLQb@c@bB}ATQPGLAP?RBVFTHhFbCz@b@????tCzAXP\\RFD??FD^t@FPBPCXGn@T?NDRPh@nAHn@j@tAt@tBJIj@_@hByAn@g@r@o@JI??jAeAfEgD|BgB|BgB??TQX[NUD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
+              },
+              "route": {
+                "type": 3,
+                "mode": "BUS",
+                "desc": "Local Bus",
+                "color": "FFC72C",
+                "gtfs_id": "mbta-ma-us:16",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": "16",
+                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                "text_color": "000000",
+                "sort_order": 50160
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:68394220",
+                "direction_id": "0",
+                "trip_headsign": "Forest Hills via South Bay Center",
+                "trip_short_name": null
+              },
+              "distance": 5043.52,
+              "headsign": "Forest Hills via South Bay Center",
+              "real_time": true,
+              "transit_leg": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:38:45-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-04-21T14:45:55-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Franklin Park Zoo",
+                "stop": null,
+                "lat": 42.305067,
+                "lon": -71.090434
+              },
+              "from": {
+                "name": "Franklin Park Zoo @ Entrance",
+                "stop": {
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "url": "https://www.mbta.com/stops/1587",
+                  "gtfs_id": "mbta-ma-us:1587",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "NO_INFORMATION",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.303124,
+                "lon": -71.08595
+              },
+              "duration": 430.0,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 43.54,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "DEPART",
+                  "street_name": "Franklin Park Road"
+                },
+                {
+                  "distance": 54.97,
+                  "absolute_direction": "NORTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 417.83,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 4.18,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                }
+              ],
+              "agency": null,
+              "leg_geometry": {
+                "length": null,
+                "points": "oieaGd~zpLFGf@`AHPSRm@t@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
+              },
+              "route": null,
+              "trip": null,
+              "distance": 520.49,
+              "headsign": null,
+              "real_time": false,
+              "transit_leg": false
+            }
+          ]
+        },
+        {
+          "start": "2025-04-21T13:54:00-04:00",
+          "end": "2025-04-21T14:58:32-04:00",
+          "duration": 3872,
+          "walk_distance": 809.28,
+          "number_of_transfers": 2,
+          "accessibility_score": null,
+          "legs": [
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T13:53:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T13:54:00-04:00",
+                  "delay": "PT1M"
+                }
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-04-21T14:12:00-04:00",
+                "estimated": {
+                  "time": "2025-04-21T14:12:31-04:00",
+                  "delay": "PT31S"
+                }
+              },
+              "to": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "from": {
+                "name": "Alewife",
+                "stop": {
+                  "name": "Alewife",
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  }
+                },
+                "lat": 42.396148,
+                "lon": -71.140698
+              },
+              "duration": 1111.0,
+              "realtime_state": null,
+              "intermediate_stops": [
+                {
+                  "name": "Davis"
+                },
+                {
+                  "name": "Porter"
+                },
+                {
+                  "name": "Harvard"
+                },
+                {
+                  "name": "Central"
+                },
+                {
+                  "name": "Kendall/MIT"
+                },
+                {
+                  "name": "Charles/MGH"
+                },
+                {
+                  "name": "Park Street"
+                }
+              ],
+              "steps": [],
+              "agency": {
+                "name": "MBTA"
+              },
+              "leg_geometry": {
+                "length": null,
+                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHnB\\tAP|@J^@JCBC??HIHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
+              },
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "DA291C",
+                "gtfs_id": "mbta-ma-us:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Red Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10010
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:67994945",
+                "direction_id": "0",
+                "trip_headsign": "Braintree",
+                "trip_short_name": null
+              },
+              "distance": 9820.78,
+              "headsign": "Braintree",
+              "real_time": true,
+              "transit_leg": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:12:31-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-04-21T14:14:18-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "from": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "duration": 107.0,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 36.12,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Concourse | CharlieCard Store"
+                },
+                {
+                  "distance": 77.57,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                },
+                {
+                  "distance": 16.46,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                }
+              ],
+              "agency": null,
+              "leg_geometry": {
+                "length": null,
+                "points": "}poaGl}upL????????"
+              },
+              "route": null,
+              "trip": null,
+              "distance": 130.15,
+              "headsign": null,
+              "real_time": false,
+              "transit_leg": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:22:00-04:00",
+                "estimated": null
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-04-21T14:34:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Jackson Square",
+                "stop": {
+                  "name": "Jackson Square",
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:70006",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
+                },
+                "lat": 42.323132,
+                "lon": -71.099592
+              },
+              "from": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "duration": 720.0,
+              "realtime_state": null,
+              "intermediate_stops": [
+                {
+                  "name": "Chinatown"
+                },
+                {
+                  "name": "Tufts Medical Center"
+                },
+                {
+                  "name": "Back Bay"
+                },
+                {
+                  "name": "Massachusetts Avenue"
+                },
+                {
+                  "name": "Ruggles"
+                },
+                {
+                  "name": "Roxbury Crossing"
+                }
+              ],
+              "steps": [],
+              "agency": {
+                "name": "MBTA"
+              },
+              "leg_geometry": {
+                "length": null,
+                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
+              },
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "ED8B00",
+                "gtfs_id": "mbta-ma-us:Orange",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Orange Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10020
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:68078680",
+                "direction_id": "0",
+                "trip_headsign": "Forest Hills",
+                "trip_short_name": null
+              },
+              "distance": 5215.25,
+              "headsign": "Forest Hills",
+              "real_time": false,
+              "transit_leg": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:34:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-04-21T14:35:01-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Jackson Square",
+                "stop": {
+                  "name": "Jackson Square",
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:11531",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
+                },
+                "lat": 42.323074,
+                "lon": -71.099546
+              },
+              "from": {
+                "name": "Jackson Square",
+                "stop": {
+                  "name": "Jackson Square",
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:70006",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
+                },
+                "lat": 42.323132,
+                "lon": -71.099592
+              },
+              "duration": 61.0,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 41.15,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to street"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to street and buses"
+                },
+                {
+                  "distance": 9.14,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "pathway"
+                },
+                {
+                  "distance": 8.53,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to buses, Centre Street"
+                },
+                {
+                  "distance": 12.19,
+                  "absolute_direction": "EAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Buses"
+                }
+              ],
+              "agency": null,
+              "leg_geometry": {
+                "length": null,
+                "points": "qfiaGns}pL????????Vv@KaA"
+              },
+              "route": null,
+              "trip": null,
+              "distance": 71.02,
+              "headsign": null,
+              "real_time": false,
+              "transit_leg": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:43:00-04:00",
+                "estimated": null
+              },
+              "mode": "BUS",
+              "end": {
+                "scheduled_time": "2025-04-21T14:50:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Seaver St opp Elm Hill Ave",
+                "stop": {
+                  "name": "Seaver St opp Elm Hill Ave",
+                  "url": "https://www.mbta.com/stops/17401",
+                  "gtfs_id": "mbta-ma-us:17401",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.307515,
+                "lon": -71.089263
+              },
+              "from": {
+                "name": "Jackson Square",
+                "stop": {
+                  "name": "Jackson Square",
+                  "url": "https://www.mbta.com/stops/place-jaksn",
+                  "gtfs_id": "mbta-ma-us:11531",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                  }
+                },
+                "lat": 42.323074,
+                "lon": -71.099546
+              },
+              "duration": 420.0,
+              "realtime_state": null,
+              "intermediate_stops": [
+                {
+                  "name": "Columbus Ave @ Dimock St"
+                },
+                {
+                  "name": "Columbus Ave opp Bray St"
+                },
+                {
+                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
+                },
+                {
+                  "name": "Columbus Ave @ Walnut Ave"
+                },
+                {
+                  "name": "Seaver St opp Harold St"
+                },
+                {
+                  "name": "Seaver St opp Humboldt Ave"
+                }
+              ],
+              "steps": [],
+              "agency": {
+                "name": "MBTA"
+              },
+              "leg_geometry": {
+                "length": null,
+                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
+              },
+              "route": {
+                "type": 3,
+                "mode": "BUS",
+                "desc": "Frequent Bus",
+                "color": "FFC72C",
+                "gtfs_id": "mbta-ma-us:22",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": "22",
+                "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
+                "text_color": "000000",
+                "sort_order": 50220
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:68394541",
+                "direction_id": "0",
+                "trip_headsign": "Ashmont",
+                "trip_short_name": null
+              },
+              "distance": 2101.86,
+              "headsign": "Ashmont",
+              "real_time": false,
+              "transit_leg": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-04-21T14:50:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-04-21T14:58:32-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Franklin Park Zoo",
+                "stop": null,
+                "lat": 42.305067,
+                "lon": -71.090434
+              },
+              "from": {
+                "name": "Seaver St opp Elm Hill Ave",
+                "stop": {
+                  "name": "Seaver St opp Elm Hill Ave",
+                  "url": "https://www.mbta.com/stops/17401",
+                  "gtfs_id": "mbta-ma-us:17401",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
                 },
                 "lat": 42.307515,
                 "lon": -71.089263

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,9 +14,11 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
     alias OpenTripPlannerClient.Schema.{
       Agency,
       Geometry,
+      IntermediateStop,
       Itinerary,
       Leg,
       LegTime,
+      ParentStop,
       Place,
       Route,
       Step,
@@ -187,14 +189,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
           build(:place, %{
             stop: build(:stop, %{gtfs_id: gtfs_prefix(agency.name) <> Faker.Internet.slug()})
           }),
-        intermediate_stops:
-          build_list(3, :stop, %{
-            gtfs_id: fn ->
-              sequence(:intermediate_stop_id, fn _ ->
-                gtfs_prefix(agency.name) <> Faker.Internet.slug()
-              end)
-            end
-          }),
+        intermediate_stops: build_list(3, :intermediate_stop),
         mode: Faker.Util.pick([:TRANSIT, :RAIL, :SUBWAY, :BUS]),
         real_time: true,
         realtime_state: Faker.Util.pick(Leg.realtime_state()),
@@ -261,11 +256,37 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
     end
 
     def stop_factory do
+      prefix = gtfs_prefix()
+
       %Stop{
-        gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
+        gtfs_id: prefix <> Faker.Internet.slug(),
         name: Faker.Address.city(),
+        url: Faker.Internet.url(),
+        vehicle_mode: Faker.Util.pick(PlanParams.modes()),
+        wheelchair_boarding: Faker.Util.pick(Stop.wheelchair_boarding()),
         zone_id:
-          [gtfs_prefix() <> Faker.Util.pick(["1A", "1", "2", "3"]), nil] |> Faker.Util.pick()
+          Faker.Util.pick([
+            "CR-zone-1A",
+            "CR-zone-1",
+            "CR-zone-2",
+            "CR-zone-3",
+            "RapidTransit",
+            "LocalBus",
+            nil
+          ]),
+        parent_station: build(:parent_stop, gtfs_id: prefix <> Faker.Internet.slug())
+      }
+    end
+
+    def intermediate_stop_factory do
+      %IntermediateStop{
+        name: Faker.Address.city()
+      }
+    end
+
+    def parent_stop_factory do
+      %ParentStop{
+        gtfs_id: gtfs_prefix() <> Faker.Internet.slug()
       }
     end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -235,6 +235,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
 
     def route_factory do
       %Route{
+        agency: build(:agency),
         gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
         short_name: Faker.Person.suffix(),
         long_name: Faker.Color.fancy_name(),
@@ -242,7 +243,8 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
         color: Faker.Color.rgb_hex(),
         text_color: Faker.Color.rgb_hex(),
         desc: Faker.Company.catch_phrase(),
-        sort_order: Faker.random_between(100, 1000)
+        sort_order: Faker.random_between(100, 1000),
+        mode: Faker.Util.pick(PlanParams.modes())
       }
     end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -263,7 +263,9 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
     def stop_factory do
       %Stop{
         gtfs_id: gtfs_prefix() <> Faker.Internet.slug(),
-        name: Faker.Address.city()
+        name: Faker.Address.city(),
+        zone_id:
+          [gtfs_prefix() <> Faker.Util.pick(["1A", "1", "2", "3"]), nil] |> Faker.Util.pick()
       }
     end
 


### PR DESCRIPTION
- feat(Route): add `agency`, as this'll help us juggling logic around whether we're showing information about MBTA routes vs Massport routes (and whatever other feeds we incorporate in the future). also add `mode`, as Dotcom can use this to derive a vehicle name.
- feat(Stop): add `zoneId` (helps Dotcom compute fares between commuter rail stations), `wheelchairBoarding` (so Dotcom can label the from or to stop as accessible), `vehicleMode`, `url`, and `parentStation`
  - for parentStation, only retrieve the gtfsId. Dotcom only needs the parentStation to calculate whether the itinerary fare Dotcom computes includes a subway transfer along the Winter Street concourse between DTX and Park Street #weirdlyspecific
- chore(Leg): adjust intermediate stops to only fetch the name for each
- chore: update the test fixture