### PR TITLE
feat(LegTime): return a single time

### DIFF
--- a/lib/open_trip_planner_client/schema/leg_time.ex
+++ b/lib/open_trip_planner_client/schema/leg_time.ex
@@ -20,6 +20,13 @@ defmodule OpenTripPlannerClient.Schema.LegTime do
     field(:estimated, Estimated.t())
   end
 
+  @doc """
+  The time, either estimated or scheduled.
+  """
+  @spec time(__MODULE__.t()) :: DateTime.t()
+  def time(%__MODULE__{estimated: %{time: time}}), do: time
+  def time(%__MODULE__{scheduled_time: time}), do: time
+
   defmodule Estimated do
     @moduledoc """
     Real-time estimates for a vehicle at a certain place.

--- a/test/open_trip_planner_client/schema/leg_time_test.exs
+++ b/test/open_trip_planner_client/schema/leg_time_test.exs
@@ -1,0 +1,23 @@
+defmodule LegTimeTest do
+  use ExUnit.Case, async: true
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
+  alias OpenTripPlannerClient.Schema.LegTime
+
+  describe "time/1" do
+    test "outputs estimated time if available" do
+      estimated = build(:leg_time_estimated)
+      leg_time = build(:leg_time, estimated: estimated)
+
+      assert LegTime.time(leg_time) == estimated.time
+      refute LegTime.time(leg_time) == leg_time.scheduled_time
+    end
+
+    test "otherwise outputs scheduled time" do
+      leg_time = build(:leg_time, estimated: nil)
+
+      assert LegTime.time(leg_time) == leg_time.scheduled_time
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -96,6 +96,13 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
       }
     end
 
+    def leg_time_estimated_factory do
+      %LegTime.Estimated{
+        delay: Faker.random_between(1, 20),
+        time: Faker.DateTime.forward(2)
+      }
+    end
+
     # Build a bunch of legs such that their start/end times follow each other
     # (e.g. creating a coherent sequence)
     defp build_leg_sequence(number) do


### PR DESCRIPTION
😅 Since a leg's start or end time could be either estimated or scheduled, this PR adds a helper function to fetch either. 

```elixir
not_an_end_time = leg.end # This is not a datetime, this is a %LegTime{}!
end_time = LegTime.time(leg.end) # *this* is a datetime
```