### PR TITLE
fix(Leg): group by mode, with more nuance

### DIFF
--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -127,10 +127,6 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     {:subway, leg.from.name, leg.to.name}
   end
 
-  def group_identifier(%__MODULE__{route: %Route{short_name: "SL" <> _, type: 3}} = leg) do
-    {:silver_line, leg.from.name, leg.to.name}
-  end
-
   def group_identifier(%__MODULE__{route: %Route{type: 3}} = leg) do
     {:bus, leg.from.name, leg.to.name}
   end

--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -127,15 +127,12 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     {:subway, leg.from.name, leg.to.name}
   end
 
-  def group_identifier(%__MODULE__{route: %Route{short_name: short_name, type: 3}} = leg) do
-    mode =
-      if String.starts_with?(short_name, "SL") do
-        :silver_line
-      else
-        :bus
-      end
+  def group_identifier(%__MODULE__{route: %Route{short_name: "SL" <> _, type: 3}} = leg) do
+    {:silver_line, leg.from.name, leg.to.name}
+  end
 
-    {mode, leg.from.name, leg.to.name}
+  def group_identifier(%__MODULE__{route: %Route{type: 3}} = leg) do
+    {:bus, leg.from.name, leg.to.name}
   end
 
   def group_identifier(leg) do

--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -127,10 +127,6 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     {:subway, leg.from.name, leg.to.name}
   end
 
-  def group_identifier(%__MODULE__{route: %Route{type: 3}} = leg) do
-    {:bus, leg.from.name, leg.to.name}
-  end
-
   def group_identifier(leg) do
     {leg.route.type, leg.from.name, leg.to.name}
   end

--- a/lib/open_trip_planner_client/schema/step.ex
+++ b/lib/open_trip_planner_client/schema/step.ex
@@ -93,6 +93,9 @@ defmodule OpenTripPlannerClient.Schema.Step do
   @spec to_atom(any()) :: {:ok, any()}
   def to_atom(term), do: {:ok, OpenTripPlannerClient.Util.to_uppercase_atom(term)}
 
+  @doc """
+  Generate a friendly description of this walking step.
+  """
   @spec walk_summary(t()) :: String.t()
   def walk_summary(%__MODULE__{relative_direction: :DEPART, street_name: "Transfer"}),
     do: "Transfer"

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,6 @@ defmodule OpenTripPlannerClient.MixProject do
         ignore_modules: [
           Mix.Tasks.UpdateFixture,
           ~r/Jason.Encoder/,
-          ~r/OpenTripPlannerClient.Schema\./,
           ~r/Nestru/
         ],
         summary: [threshold: 90]

--- a/test/open_trip_planner_client/schema/leg_test.exs
+++ b/test/open_trip_planner_client/schema/leg_test.exs
@@ -6,7 +6,7 @@ defmodule LegTest do
   alias OpenTripPlannerClient.Schema.{Leg, Route}
 
   describe "group_identifier/1" do
-    test "different value for legs between the same places using different mode" do
+    test "different value for legs between the same places using transit vs walking" do
       from = build(:place)
       to = build(:place)
       walking_leg = build(:walking_leg, from: from, to: to)
@@ -21,7 +21,7 @@ defmodule LegTest do
       to = build(:place_with_stop)
       route = build(:route)
       transit_leg = build(:transit_leg, from: from, to: to, route: %{route | type: 0})
-      other_transit_leg = build(:transit_leg, from: from, to: to, route: %{route | type: 1})
+      other_transit_leg = build(:transit_leg, from: from, to: to, route: %{route | type: 2})
 
       assert Leg.group_identifier(transit_leg) !=
                Leg.group_identifier(other_transit_leg)
@@ -49,6 +49,31 @@ defmodule LegTest do
       rail_replacement_route = build(:route, type: 3, desc: "Rail Replacement Bus")
       transit_leg = build(:transit_leg, from: from, to: to, route: bus_route)
       other_transit_leg = build(:transit_leg, from: from, to: to, route: rail_replacement_route)
+
+      assert Leg.group_identifier(transit_leg) !=
+               Leg.group_identifier(other_transit_leg)
+    end
+
+    test "different value for similar legs from different agencies" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+      route = build(:route)
+
+      transit_leg =
+        build(:transit_leg,
+          agency: build(:agency, name: "Logan Express"),
+          from: from,
+          to: to,
+          route: route
+        )
+
+      other_transit_leg =
+        build(:transit_leg,
+          agency: build(:agency, name: "Massport"),
+          from: from,
+          to: to,
+          route: route
+        )
 
       assert Leg.group_identifier(transit_leg) !=
                Leg.group_identifier(other_transit_leg)

--- a/test/open_trip_planner_client/schema/step_test.exs
+++ b/test/open_trip_planner_client/schema/step_test.exs
@@ -1,0 +1,27 @@
+defmodule StepTest do
+  use ExUnit.Case, async: true
+
+  import OpenTripPlannerClient.Test.Support.Factory
+
+  alias OpenTripPlannerClient.Schema.Step
+
+  describe "walk_summary/1" do
+    test "shows text" do
+      for relative <- Step.relative_direction(),
+          absolute <- Step.absolute_direction() do
+        step = build(:step, absolute_direction: absolute, relative_direction: relative)
+        assert Step.walk_summary(step) |> is_binary()
+      end
+    end
+
+    test "handles bogus Transfer street name" do
+      step = build(:step, street_name: "Transfer", relative_direction: :DEPART)
+      assert Step.walk_summary(step) == "Transfer"
+    end
+
+    test "handles other situations gracefully" do
+      step = build(:step, absolute_direction: :SKYWARDS, relative_direction: :JUMP)
+      assert Step.walk_summary(step) == "Go onto #{step.street_name}"
+    end
+  end
+end


### PR DESCRIPTION
`route.type` wasn't really cutting it for the "group legs by mode" idea.

_Example where a rail replacement shuttle got grouped with a regular bus:_
![image](https://github.com/user-attachments/assets/8b900981-199a-47ce-af91-22a04cce1ad0)

I figure these improvements would be more robust:
- Treat types `0` and `1` as the same like we do on Dotcom (and presumably elsewhere)
- Don't group legs from different agencies together (ever)
- Don't group Silver Line bus routes with other bus routes (because it's ✨ special ✨)
- Treat rail replacement shuttles separately

I added some tests to this, then realized we'd been excluding the `OpenTripPlannerClient.Schema.*` family of modules from test coverage, so I undid that, and then needed to add more coverage so I added some more tests.