### PR TITLE
feat: return itinerary groups

### DIFF
--- a/lib/open_trip_planner_client/behaviour.ex
+++ b/lib/open_trip_planner_client/behaviour.ex
@@ -70,7 +70,7 @@ defmodule OpenTripPlannerClient.Behaviour do
           | planner_error_code
           | String.t()
 
-  @type plan_result :: {:ok, [map()]} | {:error, error()}
+  @type plan_result :: {:ok, [OpenTripPlannerClient.ItineraryGroup.t()]} | {:error, error()}
   @callback plan(params :: PlanParams.t()) :: plan_result()
   @callback plan(
               params :: PlanParams.t(),

--- a/lib/open_trip_planner_client/itinerary_group.ex
+++ b/lib/open_trip_planner_client/itinerary_group.ex
@@ -83,6 +83,7 @@ defmodule OpenTripPlannerClient.ItineraryGroup do
     legs
     |> Enum.uniq_by(&combined_leg_to_tuple/1)
     |> Enum.reduce(%{walk_minutes: 0, routes: []}, &summarize_legs/2)
+    |> Map.update!(:walk_minutes, &(Kernel.round(&1) |> Kernel.max(1)))
   end
 
   defp combined_leg_to_tuple(%Leg{transit_leg: false} = leg) do

--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -115,9 +115,14 @@ defmodule OpenTripPlannerClient.Schema.Leg do
 
   @doc """
   To be grouped together, legs must share these characteristics:
+  - Same transit agency
   - Same origin and destination
   - Same :transit_leg value (e.g. walking legs don't get grouped with transit legs)
-  - Same transit mode, or using rail replacement buses
+  - Similar transit mode, where
+      - rail replacement buses are treated independently
+      - each subway line is treated independently
+      - branches in a line can be grouped together (GL B/C/D/E, SL 1/2/3)
+      - SL4/5 are grouped with buses
   """
   @spec group_identifier(__MODULE__.t()) :: tuple()
   def group_identifier(%__MODULE__{transit_leg: false} = leg) do
@@ -133,11 +138,32 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     {:shuttle, leg.from.name, leg.to.name}
   end
 
-  def group_identifier(%__MODULE__{route: %Route{type: type}} = leg) when type in [0, 1] do
-    {:subway, leg.from.name, leg.to.name}
+  def group_identifier(%__MODULE__{route: %Route{type: type} = route} = leg)
+      when type in [0, 1] do
+    route_id = mbta_id(route)
+
+    if String.starts_with?(route_id, "Green") do
+      {:green_line, leg.from.name, leg.to.name}
+    else
+      {route_id, leg.from.name, leg.to.name}
+    end
+  end
+
+  def group_identifier(%__MODULE__{route: %Route{type: 3} = route} = leg) do
+    route_id = mbta_id(route)
+    silver_line_rapid_transit_ids = ~w(741 742 743)
+
+    if route_id in silver_line_rapid_transit_ids do
+      {:silver_line, leg.from.name, leg.to.name}
+    else
+      {leg.route.type, leg.from.name, leg.to.name}
+    end
   end
 
   def group_identifier(leg) do
     {leg.route.type, leg.from.name, leg.to.name}
   end
+
+  defp mbta_id(%{gtfs_id: "mbta-ma-us:" <> id}), do: id
+  defp mbta_id(_), do: nil
 end

--- a/test/open_trip_planner_client/http_test.exs
+++ b/test/open_trip_planner_client/http_test.exs
@@ -13,7 +13,7 @@ defmodule OpenTripPlannerClient.HttpTest do
   import OpenTripPlannerClient.Test.Support.Factory
   import Plug.Conn, only: [send_resp: 3]
 
-  alias OpenTripPlannerClient.{ItineraryTag, Plan}
+  alias OpenTripPlannerClient.{ItineraryGroup, ItineraryTag, Plan}
 
   setup context do
     if context[:external] do
@@ -46,7 +46,7 @@ defmodule OpenTripPlannerClient.HttpTest do
         |> Plug.Conn.send_resp(:ok, @fixture)
       end)
 
-      {:ok, plan} =
+      {:ok, itinerary_groups} =
         plan(
           build(:plan_params),
           [
@@ -56,15 +56,24 @@ defmodule OpenTripPlannerClient.HttpTest do
           ]
         )
 
-      assert plan.itineraries
+      assert itinerary_groups
 
-      {tagged, untagged} = Enum.split_while(plan.itineraries, &(!is_nil(&1.tag)))
+      {untagged, tagged} =
+        Enum.split_with(itinerary_groups, fn group ->
+          representative_tag(group)
+          |> is_nil()
+        end)
 
       assert untagged
-             |> Enum.map(& &1.tag)
+             |> Enum.map(&representative_tag/1)
              |> Enum.all?(&is_nil/1)
 
-      assert :earliest_arrival in Enum.map(tagged, & &1.tag)
+      assert Enum.map(tagged, &representative_tag/1) |> Enum.all?()
+    end
+
+    defp representative_tag(group) do
+      ItineraryGroup.representative_itinerary(group)
+      |> Map.get(:tag)
     end
   end
 

--- a/test/open_trip_planner_client/itinerary_group_test.exs
+++ b/test/open_trip_planner_client/itinerary_group_test.exs
@@ -114,7 +114,29 @@ defmodule OpenTripPlannerClient.ItineraryGroupTest do
         build_list(2, :itinerary, legs: [long_leg, short_leg, long_leg])
         |> ItineraryGroup.groups_from_itineraries()
 
-      assert [%{walk_minutes: 10.0}, %{walk_minutes: 10.0}] = ItineraryGroup.leg_summaries(group)
+      assert [%{walk_minutes: 10}, %{walk_minutes: 10}] = ItineraryGroup.leg_summaries(group)
+    end
+
+    test "rounds minutes to minimum 1" do
+      seconds = Faker.random_between(1, 30)
+      very_short_leg = build(:walking_leg, duration: seconds)
+
+      [group] =
+        build_list(2, :itinerary, legs: [very_short_leg])
+        |> ItineraryGroup.groups_from_itineraries()
+
+      assert [%{walk_minutes: 1}] = ItineraryGroup.leg_summaries(group)
+    end
+
+    test "rounds minutes to nearest integer" do
+      leg = build(:walking_leg, duration: Faker.random_uniform() * 600)
+
+      [group] =
+        build_list(2, :itinerary, legs: [leg])
+        |> ItineraryGroup.groups_from_itineraries()
+
+      assert [%{walk_minutes: minutes}] = ItineraryGroup.leg_summaries(group)
+      assert is_integer(minutes)
     end
   end
 

--- a/test/open_trip_planner_client/schema/leg_test.exs
+++ b/test/open_trip_planner_client/schema/leg_test.exs
@@ -30,13 +30,12 @@ defmodule LegTest do
     test "same value for legs between the same places using same route type" do
       from = build(:place_with_stop)
       to = build(:place_with_stop)
-      route_type = Faker.Util.pick(Route.gtfs_route_type())
 
       transit_leg =
-        build(:transit_leg, from: from, to: to, route: build(:route, type: route_type))
+        build(:transit_leg, from: from, to: to, route: build(:route, type: 4))
 
       other_transit_leg =
-        build(:transit_leg, from: from, to: to, route: build(:route, type: route_type))
+        build(:transit_leg, from: from, to: to, route: build(:route, type: 4))
 
       assert Leg.group_identifier(transit_leg) ==
                Leg.group_identifier(other_transit_leg)
@@ -77,6 +76,58 @@ defmodule LegTest do
 
       assert Leg.group_identifier(transit_leg) !=
                Leg.group_identifier(other_transit_leg)
+    end
+
+    test "Silver Line 1/2/3 doesn't group with buses" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+      bus_route = build(:route, gtfs_id: "mbta-ma-us:not-silver-line", type: 3)
+      sl_route = build(:route, gtfs_id: "mbta-ma-us:#{Faker.Util.pick(~w(741 742 743))}", type: 3)
+      bus_leg = build(:transit_leg, from: from, to: to, route: bus_route)
+      sl_leg = build(:transit_leg, from: from, to: to, route: sl_route)
+
+      assert Leg.group_identifier(bus_leg) != Leg.group_identifier(sl_leg)
+    end
+
+    test "Silver Line 1/2/3 grouped with each other" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+
+      [route1, route2] =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(~w(741 742 743)) end)
+        |> Enum.map(&build(:route, gtfs_id: "mbta-ma-us:#{&1}", type: 3))
+
+      leg1 = build(:transit_leg, from: from, to: to, route: route1)
+      leg2 = build(:transit_leg, from: from, to: to, route: route2)
+
+      assert Leg.group_identifier(leg1) == Leg.group_identifier(leg2)
+    end
+
+    test "Green Line B/C/D/E grouped with each other" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+
+      [route1, route2] =
+        Faker.Util.sample_uniq(2, fn -> Faker.Util.pick(~w(Green-B Green-C Green-D Green-E)) end)
+        |> Enum.map(&build(:route, gtfs_id: "mbta-ma-us:#{&1}", type: 0))
+
+      leg1 = build(:transit_leg, from: from, to: to, route: route1)
+      leg2 = build(:transit_leg, from: from, to: to, route: route2)
+
+      assert Leg.group_identifier(leg1) == Leg.group_identifier(leg2)
+    end
+
+    test "subways not otherwise grouped with each other" do
+      from = build(:place_with_stop)
+      to = build(:place_with_stop)
+
+      [route1, route2] =
+        Faker.Util.sample_uniq(2, fn -> build(:route, type: 1) end)
+
+      leg1 = build(:transit_leg, from: from, to: to, route: route1)
+      leg2 = build(:transit_leg, from: from, to: to, route: route2)
+
+      assert Leg.group_identifier(leg1) != Leg.group_identifier(leg2)
     end
   end
 end


### PR DESCRIPTION
> [!CAUTION]
> First breaking change! Instead of returning a list of itineraries, `plan/2` now returns a list of _**itinerary groups**_. 

Itineraries are grouped together based on how similar the legs are. Most of that logic was added in 
- #6 

While using this branch in Dotcom (PR TBA), I found some smaller fixes which I'm including here:
 - when summarizing the legs, round the aggregated walk minutes to the nearest minute (or 1)
 - refine the leg grouping further, mainly to avoid grouping different subway lines together, and refine how Silver Line routes are handled when grouping

