### PR TITLE
hotfix: Use identifiers rather than summaries to tell when a trip is unavailable

### DIFF
--- a/lib/open_trip_planner_client/itinerary_group.ex
+++ b/lib/open_trip_planner_client/itinerary_group.ex
@@ -61,7 +61,7 @@ defmodule OpenTripPlannerClient.ItineraryGroup do
   # - generalized cost is better than all groups from the actual GTFS
   # - summarized walk/transit legs isn't already present in the actual groups
   defp select_unavailable_groups(ideal_groups, actual_groups) do
-    group_summaries = Enum.map(actual_groups, & &1.summary)
+    group_identifiers = Enum.map(actual_groups, & &1.identifier)
 
     group_cost_threshold =
       actual_groups
@@ -71,7 +71,7 @@ defmodule OpenTripPlannerClient.ItineraryGroup do
     ideal_groups
     |> Stream.reject(&all_mbta_bus_legs?/1)
     |> Stream.reject(&(generalized_cost(&1) >= group_cost_threshold))
-    |> Stream.reject(&(&1.summary in group_summaries))
+    |> Stream.reject(&(&1.identifier in group_identifiers))
   end
 
   defp to_groups(itineraries, opts) do


### PR DESCRIPTION
This avoids silliness like 👇 

<img width="927" height="710" alt="Screenshot 2025-07-24 at 4 28 32 PM" src="https://github.com/user-attachments/assets/2a719dd5-83e1-4d98-b05f-700bef269f54" />

The bug is that the `summary` field has the GTFS ID (that is - `mbta-ma-us` versus `mbta-ma-us-initial`) in it, so when we check "is this itinerary's summary in the `available_summaries` list?", the answer is always no, which means that the unavailable calculation thinks that _all_ ideal trips are unavailable. (The only reason that we don't show more is because we only show trips as unavailable if their `generalized_cost` is lower than any actual trips).
