### PR TITLE
feat: use planConnection

### DIFF
--- a/lib/open_trip_planner_client/error.ex
+++ b/lib/open_trip_planner_client/error.ex
@@ -6,7 +6,6 @@ defmodule OpenTripPlannerClient.Error do
   """
 
   alias OpenTripPlannerClient.Plan
-  alias Timex.{Duration, Format.Duration.Formatter}
 
   require Logger
 
@@ -62,9 +61,9 @@ defmodule OpenTripPlannerClient.Error do
   end
 
   defp code_to_message("NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW", _, %Plan{} = plan) do
-    with window when is_binary(window) <- humanized_search_window(plan.search_window_used),
-         {:ok, formatted_datetime} <- humanized_full_date(plan.date) do
-      "No transit routes found within #{window} of #{formatted_datetime}. Routes may be available at other times."
+    with {:ok, datetime, _} <- DateTime.from_iso8601(plan.search_date_time),
+         {:ok, formatted_datetime} <- humanized_full_date(datetime) do
+      "No transit routes found within 2 hours of #{formatted_datetime}. Routes may be available at other times."
     else
       _ ->
         fallback_error_message()
@@ -72,12 +71,6 @@ defmodule OpenTripPlannerClient.Error do
   end
 
   defp code_to_message(_, _, _), do: fallback_error_message()
-
-  defp humanized_search_window(number) do
-    number
-    |> Duration.from_seconds()
-    |> Formatter.format(:humanized)
-  end
 
   defp humanized_full_date(datetime) do
     datetime

--- a/lib/open_trip_planner_client/plan.ex
+++ b/lib/open_trip_planner_client/plan.ex
@@ -16,32 +16,29 @@ defmodule OpenTripPlannerClient.Plan do
         map
         |> update_in([:routing_errors], &replace_nil_with_list/1)
         |> update_in([:itineraries], &replace_nil_with_list/1)
-        |> update_in([:date], fn
-          dt when is_integer(dt) ->
-            OpenTripPlannerClient.Util.to_local_time(dt)
+        |> update_in([:itineraries], fn edges -> Enum.map(edges, &unwrap_node/1) end)
 
-          dt ->
-            dt
-        end)
 
       {:ok, updated_map}
     end
 
     defp replace_nil_with_list(nil), do: []
     defp replace_nil_with_list(other), do: other
+
+    defp unwrap_node(%{node: node}), do: node
+    defp unwrap_node(other), do: other
   end
 
   @derive {Nestru.Decoder,
            hint: %{
-             date: DateTime,
              itineraries: [Itinerary],
-             routing_errors: [OpenTripPlannerClient.Plan.RoutingError]
+             routing_errors: [OpenTripPlannerClient.Plan.RoutingError],
+             search_date_time: DateTime
            }}
   schema do
-    field(:date, DateTime)
     field(:itineraries, [Itinerary.t()])
     field(:routing_errors, [RoutingError.t()])
-    field(:search_window_used, non_neg_integer())
+    field(:search_date_time, DateTime)
   end
 
   defmodule RoutingError do

--- a/lib/open_trip_planner_client/plan.ex
+++ b/lib/open_trip_planner_client/plan.ex
@@ -18,7 +18,6 @@ defmodule OpenTripPlannerClient.Plan do
         |> update_in([:itineraries], &replace_nil_with_list/1)
         |> update_in([:itineraries], fn edges -> Enum.map(edges, &unwrap_node/1) end)
 
-
       {:ok, updated_map}
     end
 

--- a/lib/open_trip_planner_client/plan_params.ex
+++ b/lib/open_trip_planner_client/plan_params.ex
@@ -115,7 +115,7 @@ defmodule OpenTripPlannerClient.PlanParams do
           dateTime: datetime_map(),
           numItineraries: integer(),
           destination: place_location_input(),
-          transportModes: transport_modes(),
+          transportModes: map(),
           wheelchair: wheelchair()
         }
 
@@ -130,7 +130,7 @@ defmodule OpenTripPlannerClient.PlanParams do
   @spec new(place_map(), place_map(), opts()) :: t()
   def new(origin, destination, opts \\ []) do
     datetime = Keyword.get(opts, :datetime, OpenTripPlannerClient.Util.local_now())
-    modes = Keyword.get(opts, :modes, [:RAIL, :SUBWAY, :TRAM, :BUS, :FERRY])
+    modes = Keyword.get(opts, :modes, [])
 
     %__MODULE__{
       origin: to_location_param(origin),
@@ -142,7 +142,10 @@ defmodule OpenTripPlannerClient.PlanParams do
     }
   end
 
-  @spec to_modes_param([mode_t()]) :: transport_modes()
+  @spec to_modes_param([mode_t()]) :: map()
+  # Will default to all modes being usable
+  defp to_modes_param([]), do: %{}
+
   defp to_modes_param(modes) do
     modes
     |> then(fn modes ->
@@ -153,6 +156,13 @@ defmodule OpenTripPlannerClient.PlanParams do
       end
     end)
     |> Enum.map(&Map.new(mode: &1))
+    |> then(
+      &%{
+        transit: %{
+          transit: &1
+        }
+      }
+    )
   end
 
   @spec to_datetime_param(boolean(), DateTime.t()) :: map()

--- a/lib/open_trip_planner_client/plan_params.ex
+++ b/lib/open_trip_planner_client/plan_params.ex
@@ -143,8 +143,11 @@ defmodule OpenTripPlannerClient.PlanParams do
   end
 
   @spec to_modes_param([mode_t()]) :: map()
-  # Will default to all modes being usable
-  defp to_modes_param([]), do: %{}
+  # Our way of doing "walk only" -- no transit modes!
+  defp to_modes_param([]),
+    do: %{
+      directOnly: true
+    }
 
   defp to_modes_param(modes) do
     modes

--- a/lib/open_trip_planner_client/plan_params.ex
+++ b/lib/open_trip_planner_client/plan_params.ex
@@ -1,87 +1,63 @@
 defmodule OpenTripPlannerClient.PlanParams do
   @moduledoc """
-  Data type describing params for the plan query.
-  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/plan
+  Data type describing params for the planConnection query.
+  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/planConnection
   """
-
-  @doc "Data type describing params for the plan query.
-  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/plan"
+  @doc "Data type describing params for the planConnection query.
+  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/planConnection"
   @derive Jason.Encoder
   defstruct [
-    :fromPlace,
-    :toPlace,
-    :date,
-    :time,
-    arriveBy: false,
+    :origin,
+    :destination,
+    :dateTime,
     numItineraries: 5,
-    transportModes: [%{mode: :WALK}, %{mode: :TRANSIT}],
+    transportModes: [
+      %{mode: :RAIL},
+      %{mode: :SUBWAY},
+      %{mode: :TRAM},
+      %{mode: :BUS},
+      %{mode: :FERRY}
+    ],
     wheelchair: false
   ]
 
   @typedoc """
-  Whether the itinerary should depart at the specified time (false), or arrive
-  to the destination at the specified time (true). Default value: false.
+  Datetime of departure or arrival in ISO8601Extended format. Default value: current datetime
   """
-  @type arrive_by :: boolean()
+  @type datetime :: String.t()
+  @type datetime_map :: %{earliestDeparture: datetime()} | %{latestArrival: datetime()}
 
   @typedoc """
-  Date of departure or arrival in format YYYY-MM-DD. Default value: current date
-  """
-  @type date :: String.t()
-
-  @typedoc """
-  The place where the itinerary begins or ends in format name::place, where
-  place is either a lat,lng pair (e.g. Pasila::60.199041,24.932928) or a stop id
-  (e.g. Pasila::HSL:1000202)
-
-  "New England Title Insurance Company, 151 Tremont St, Boston, MA, 02111,
-  USA::42.354452,-71.06338" "Newton Highlands::mbta-ma-us:place-nwtn"
-  """
-  @type place :: String.t()
-
-  @typedoc """
-  Time of departure or arrival in format hh:mm:ss. Default value: current time
-  """
-  @type time :: String.t()
-
-  @typedoc """
-  List of transportation modes that the user is willing to use. Default:
-  ["WALK","TRANSIT"]
+  List of transportation modes that the user is willing to use.
   """
   @type transport_modes :: nonempty_list(transport_mode())
   @typep transport_mode :: %{mode: mode_t()}
 
   @modes [
     :AIRPLANE,
-    :BICYCLE,
     :BUS,
     :CABLE_CAR,
-    :CAR,
     # Private car trips shared with others
     :CARPOOL,
     :COACH,
     :FERRY,
-    # Enables flexible transit for access and egress legs
-    :FLEX,
     :FUNICULAR,
     :GONDOLA,
     # Railway in which the track consists of a single rail or a beam.
     :MONORAIL,
+    # This includes long or short distance trains.
     :RAIL,
-    :SCOOTER,
+    # Subway or metro, depending on the local terminology.
     :SUBWAY,
     # A taxi, possibly operated by a public transport agency.
     :TAXI,
     :TRAM,
-    # A special transport mode, which includes all public transport.
-    :TRANSIT,
     # Electric buses that draw power from overhead wires using poles.
-    :TROLLEYBUS,
-    :WALK
+    :TROLLEYBUS
   ]
 
   @typedoc """
-  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/Mode
+  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/TransitMode
   """
   @type mode_t ::
           unquote(
@@ -98,7 +74,16 @@ defmodule OpenTripPlannerClient.PlanParams do
   @typedoc """
   Specifying an origin or destination for trip planning.
   """
-  @type place_map :: %{optional(any()) => any(), latitude: float(), longitude: float()}
+  @type place_map :: %{name: String.t(), latitude: float(), longitude: float()}
+  @type place_location_input :: %{
+          label: String.t(),
+          location: %{
+            coordinate: %{
+              latitude: float(),
+              longitude: float()
+            }
+          }
+        }
 
   @typedoc """
   Customization options for trip planning.
@@ -107,8 +92,7 @@ defmodule OpenTripPlannerClient.PlanParams do
     `false`, depart at a certain time. Defalts to false.
   * `:datetime` - The DateTime to depart from the origin or arrive at the
     destination. Defaults to now.
-  * `:modes` - The transit modes to be used in the plan. Defaults to
-    [:WALK, :TRANSIT]
+  * `:modes` - The transit modes to be used in the plan. Defaults to all modes.
   * `:num_itineraries` - The maximum number of itineraries to return. Defaults
     to 5.
   * `:wheelchair` - Whether to limit itineraries to those that are wheelchair 
@@ -127,12 +111,10 @@ defmodule OpenTripPlannerClient.PlanParams do
   Arguments for the OTP plan query.
   """
   @type t :: %__MODULE__{
-          arriveBy: arrive_by(),
-          fromPlace: place(),
-          date: date(),
+          origin: place_location_input(),
+          dateTime: datetime_map(),
           numItineraries: integer(),
-          time: time(),
-          toPlace: place(),
+          destination: place_location_input(),
           transportModes: transport_modes(),
           wheelchair: wheelchair()
         }
@@ -146,26 +128,18 @@ defmodule OpenTripPlannerClient.PlanParams do
   Defaults to 5 itineraries departing at the current time via walking or any mode of transit.
   """
   @spec new(place_map(), place_map(), opts()) :: t()
-  def new(from, to, opts \\ []) do
+  def new(origin, destination, opts \\ []) do
     datetime = Keyword.get(opts, :datetime, OpenTripPlannerClient.Util.local_now())
-    modes = Keyword.get(opts, :modes, [:WALK, :TRANSIT])
+    modes = Keyword.get(opts, :modes, [:RAIL, :SUBWAY, :TRAM, :BUS, :FERRY])
 
     %__MODULE__{
-      fromPlace: to_place_param(from),
-      toPlace: to_place_param(to),
-      arriveBy: Keyword.get(opts, :arrive_by, false),
-      date: to_date_param(datetime),
+      origin: to_location_param(origin),
+      destination: to_location_param(destination),
+      dateTime: Keyword.get(opts, :arrive_by, false) |> to_datetime_param(datetime),
       numItineraries: Keyword.get(opts, :num_itineraries, 5),
-      time: to_time_param(datetime),
       transportModes: to_modes_param(modes),
       wheelchair: Keyword.get(opts, :wheelchair, false)
     }
-  end
-
-  @spec to_place_param(place_map()) :: place()
-  defp to_place_param(%{latitude: latitude, longitude: longitude} = place)
-       when is_float(latitude) and is_float(longitude) do
-    "#{Map.get(place, :name, "")}::#{latitude},#{longitude}"
   end
 
   @spec to_modes_param([mode_t()]) :: transport_modes()
@@ -181,17 +155,17 @@ defmodule OpenTripPlannerClient.PlanParams do
     |> Enum.map(&Map.new(mode: &1))
   end
 
-  @spec to_date_param(DateTime.t()) :: date()
-  defp to_date_param(datetime) do
-    format_datetime(datetime, "{YYYY}-{0M}-{0D}")
+  @spec to_datetime_param(boolean(), DateTime.t()) :: map()
+  defp to_datetime_param(true, datetime) do
+    %{latestArrival: DateTime.to_iso8601(datetime)}
   end
 
-  @spec to_time_param(DateTime.t()) :: time()
-  defp to_time_param(datetime) do
-    format_datetime(datetime, "{h12}:{m}{am}")
+  defp to_datetime_param(false, datetime) do
+    %{earliestDeparture: DateTime.to_iso8601(datetime)}
   end
 
-  defp format_datetime(datetime, formatter) do
-    Timex.format!(datetime, formatter)
+  @spec to_location_param(place_map()) :: place_location_input()
+  defp to_location_param(%{name: name} = map) do
+    %{label: name, location: %{coordinate: Map.take(map, [:latitude, :longitude])}}
   end
 end

--- a/lib/open_trip_planner_client/plan_params.ex
+++ b/lib/open_trip_planner_client/plan_params.ex
@@ -10,14 +10,8 @@ defmodule OpenTripPlannerClient.PlanParams do
     :origin,
     :destination,
     :dateTime,
+    :modes,
     numItineraries: 5,
-    transportModes: [
-      %{mode: :RAIL},
-      %{mode: :SUBWAY},
-      %{mode: :TRAM},
-      %{mode: :BUS},
-      %{mode: :FERRY}
-    ],
     wheelchair: false
   ]
 
@@ -115,7 +109,7 @@ defmodule OpenTripPlannerClient.PlanParams do
           dateTime: datetime_map(),
           numItineraries: integer(),
           destination: place_location_input(),
-          transportModes: map(),
+          modes: map(),
           wheelchair: wheelchair()
         }
 
@@ -137,7 +131,7 @@ defmodule OpenTripPlannerClient.PlanParams do
       destination: to_location_param(destination),
       dateTime: Keyword.get(opts, :arrive_by, false) |> to_datetime_param(datetime),
       numItineraries: Keyword.get(opts, :num_itineraries, 5),
-      transportModes: to_modes_param(modes),
+      modes: to_modes_param(modes),
       wheelchair: Keyword.get(opts, :wheelchair, false)
     }
   end

--- a/lib/open_trip_planner_client/schema.ex
+++ b/lib/open_trip_planner_client/schema.ex
@@ -48,20 +48,20 @@ defmodule OpenTripPlannerClient.Schema do
   defimpl Nestru.Encoder, for: DateTime do
     # credo:disable-for-next-line
     def gather_fields_from_struct(struct, _) do
-      {:ok, DateTime.to_string(struct)}
+      {:ok, DateTime.to_iso8601(struct)}
     end
   end
 
   defimpl Nestru.Decoder, for: DateTime do
     # credo:disable-for-next-line
     def decode_fields_hint(_, _, %DateTime{} = dt) do
-      {:ok, OpenTripPlannerClient.Util.to_local_time(dt)}
+      {:ok, dt}
     end
 
     # credo:disable-for-next-line
     def decode_fields_hint(_, _, value) do
-      case Timex.parse(value, "{ISO:Extended}") do
-        {:ok, dt} ->
+      case DateTime.from_iso8601(value) do
+        {:ok, dt, _} ->
           {:ok, OpenTripPlannerClient.Util.to_local_time(dt)}
 
         error ->

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -1,128 +1,133 @@
 query TripPlan(
-  $fromPlace: String!
-  $toPlace: String!
-  $date: String
-  $time: String
-  $arriveBy: Boolean
+  $origin: PlanLabeledLocationInput!
+  $destination: PlanLabeledLocationInput!
+  $dateTime: PlanDateTimeInput
   $wheelchair: Boolean
-  $transportModes: [TransportMode]
+  $transportModes: [PlanTransitModePreferenceInput!]
   $numItineraries: Int
 ) {
-  actualPlan: plan(
-    fromPlace: $fromPlace
-    toPlace: $toPlace
-    date: $date
-    time: $time
-    arriveBy: $arriveBy
-    wheelchair: $wheelchair
-    transportModes: $transportModes
-
-    # A 2-hour search window accomodates infrequent routes
-    searchWindow: 7200
-
-    # Increased from 3 to offer more itineraries for potential post-processing
-    numItineraries: $numItineraries
-
-    # Increased from 2.0 to reduce number of itineraries with significant walking
-    walkReluctance: 5.0
-
-    # Theoretically can be configured in the future for visitors using translation?
+  actualPlan: planConnection(
+    origin: $origin,
+    destination: $destination,
+    dateTime: $dateTime,
+    preferences: {
+      accessibility: {
+        wheelchair: {
+          enabled: $wheelchair
+        }
+      },
+      street: {
+        walk: {
+          reluctance: 5.0
+        }
+      },
+      transit: {
+        filters: [
+          { exclude: [{ agencies: ["mbta-ma-us-initial:1"] }]}
+        ]
+      }
+    },
+    modes: {
+      transit: {
+        transit: $transportModes
+      }
+    },
+    searchWindow: "2h"
+    first: $numItineraries
     locale: "en"
-
-    # Prefer MBTA transit legs over Massport or others.
-    preferred: { agencies: "mbta-ma-us:1" }
-
-    # Ban the initial feed
-    banned: { agencies: "mbta-ma-us-initial:1" }
   ) { ...PlanInfo }
 
-  idealPlan: plan(
-    fromPlace: $fromPlace
-    toPlace: $toPlace
-    date: $date
-    time: $time
-    arriveBy: $arriveBy
-    wheelchair: $wheelchair
-    transportModes: $transportModes
-
-    # A 2-hour search window accomodates infrequent routes
-    searchWindow: 7200
-
-    # Increased from 3 to offer more itineraries for potential post-processing
-    numItineraries: $numItineraries
-
-    # Increased from 2.0 to reduce number of itineraries with significant walking
-    walkReluctance: 5.0
-
-    # Theoretically can be configured in the future for visitors using translation?
+  idealPlan: planConnection(
+    origin: $origin,
+    destination: $destination,
+    dateTime: $dateTime,
+    preferences: {
+      accessibility: {
+        wheelchair: {
+          enabled: $wheelchair
+        }
+      },
+      street: {
+        walk: {
+          reluctance: 5.0
+        }
+      },
+      transit: {
+        filters: [
+          { include: [{ agencies: ["mbta-ma-us-initial:1"] }]}
+        ]
+      }
+    },
+    modes: {
+      transit: {
+        transit: $transportModes
+      }
+    },
+    searchWindow: "2h"
+    first: $numItineraries
     locale: "en"
-
-    # Prefer MBTA transit legs over Massport or others.
-    preferred: { agencies: "mbta-ma-us-initial:1" }
-
-    # Ban the regular feed
-    banned: { agencies: "mbta-ma-us:1" }
   ) { ...PlanInfo }
 }
 
-fragment PlanInfo on Plan {
-  searchWindowUsed
-  date
+fragment PlanInfo on PlanConnection {
+  searchDateTime
   routingErrors {
     code
     description
   }
-  itineraries {
-    accessibilityScore
-    duration
-    end
-    generalizedCost
-    legs {
-      agency { name }
-      distance
+  itineraries: edges {
+    node {
+      accessibilityScore
       duration
-      end { ...TimeInfo }
-      from { ...PlaceInfo }
-      headsign
-      intermediateStops { 
-        gtfsId,
-        name
-      }
-      legGeometry { points }
-      mode
-      realTime
-      realtimeState
-      route { 
+      end
+      generalizedCost
+      legs {
         agency { name }
-        gtfsId
-        shortName
-        longName
-        type
-        color
-        textColor
-        desc
-        sortOrder
-        mode
-      }
-      start { ...TimeInfo }
-      steps {
         distance
-        streetName
-        absoluteDirection
-        relativeDirection
+        duration
+        end { ...TimeInfo }
+        from { ...PlaceInfo }
+        headsign
+        intermediateStops { 
+          gtfsId,
+          name
+        }
+        legGeometry { points }
+        mode
+        realTime
+        realtimeState
+        route { 
+          agency { name }
+          gtfsId
+          shortName
+          longName
+          type
+          color
+          textColor
+          desc
+          sortOrder
+          mode
+        }
+        start { ...TimeInfo }
+        steps {
+          distance
+          streetName
+          absoluteDirection
+          relativeDirection
+        }
+        to { ...PlaceInfo }
+        transitLeg
+        trip {
+          directionId
+          gtfsId
+          tripHeadsign
+          tripShortName
+        }
       }
-      to { ...PlaceInfo }
-      transitLeg
-      trip {
-        directionId
-        gtfsId
-        tripHeadsign
-        tripShortName
-      }
+      numberOfTransfers
+      start
+      walkDistance
     }
-    numberOfTransfers
-    start
-    walkDistance
   }
 }
 

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -3,7 +3,7 @@ query TripPlan(
   $destination: PlanLabeledLocationInput!
   $dateTime: PlanDateTimeInput
   $wheelchair: Boolean
-  $transportModes: [PlanTransitModePreferenceInput!]
+  $modes: PlanModesInput
   $numItineraries: Int
 ) {
   actualPlan: planConnection(
@@ -27,11 +27,7 @@ query TripPlan(
         ]
       }
     },
-    modes: {
-      transit: {
-        transit: $transportModes
-      }
-    },
+    modes: $modes,
     searchWindow: "2h"
     first: $numItineraries
     locale: "en"
@@ -58,11 +54,7 @@ query TripPlan(
         ]
       }
     },
-    modes: {
-      transit: {
-        transit: $transportModes
-      }
-    },
+    modes: $modes,
     searchWindow: "2h"
     first: $numItineraries
     locale: "en"

--- a/test/fixture/alewife_to_franklin_park_zoo.json
+++ b/test/fixture/alewife_to_franklin_park_zoo.json
@@ -1,30 +1,27 @@
 {
   "data": {
     "actual_plan": {
-      "date": "2025-07-16T12:14:00.000-04:00",
+      "routing_errors": [],
       "itineraries": [
         {
-          "start": "2025-07-16T12:15:12-04:00",
-          "end": "2025-07-16T13:16:29-04:00",
-          "duration": 3677,
-          "generalized_cost": 8709,
-          "walk_distance": 1087.19,
-          "number_of_transfers": 2,
+          "start": "2025-08-05T15:14:11-04:00",
+          "end": "2025-08-05T16:15:08-04:00",
+          "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:04:00-04:00",
+                "scheduled_time": "2025-08-05T15:15:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T12:17:01-04:00",
-                  "delay": "PT13M1S"
+                  "time": "2025-08-05T15:16:00-04:00",
+                  "delay": "PT1M"
                 }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:23:00-04:00",
+                "scheduled_time": "2025-08-05T15:34:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T12:37:02-04:00",
-                  "delay": "PT14M2S"
+                  "time": "2025-08-05T15:33:35-04:00",
+                  "delay": "-PT25S"
                 }
               },
               "to": {
@@ -59,26 +56,26 @@
                 "lat": 42.396148,
                 "lon": -71.140698
               },
-              "duration": 1201.0,
-              "realtime_state": null,
+              "duration": 1055.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
-                "sort_order": 10010,
                 "gtfs_id": "mbta-ma-us:Red",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Red Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10010
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
                   "name": "Davis"
@@ -108,7 +105,7 @@
                 "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69349294",
+                "gtfs_id": "mbta-ma-us:69349312",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
@@ -119,12 +116,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:37:02-04:00",
+                "scheduled_time": "2025-08-05T15:33:35-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:38:49-04:00",
+                "scheduled_time": "2025-08-05T15:35:24-04:00",
                 "estimated": null
               },
               "to": {
@@ -159,11 +156,11 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 107.0,
-              "realtime_state": null,
+              "duration": 109.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -202,29 +199,35 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:42:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-08-05T15:38:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:39:11-04:00",
+                  "delay": "PT1M11S"
+                }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:54:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-08-05T15:56:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:54:30-04:00",
+                  "delay": "-PT1M30S"
+                }
               },
               "to": {
-                "name": "Jackson Square",
+                "name": "Forest Hills",
                 "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:70006",
+                  "name": "Forest Hills",
+                  "url": "https://www.mbta.com/stops/place-forhl",
+                  "gtfs_id": "mbta-ma-us:70001",
                   "vehicle_mode": "SUBWAY",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "RapidTransit",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                    "gtfs_id": "mbta-ma-us:place-forhl"
                   }
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
+                "lat": 42.300926,
+                "lon": -71.114129
               },
               "from": {
                 "name": "Downtown Crossing",
@@ -242,26 +245,26 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 720.0,
-              "realtime_state": null,
+              "duration": 919.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "ED8B00",
-                "sort_order": 10020,
                 "gtfs_id": "mbta-ma-us:Orange",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Orange Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10020
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
                   "name": "Chinatown"
@@ -280,212 +283,209 @@
                 },
                 {
                   "name": "Roxbury Crossing"
+                },
+                {
+                  "name": "Jackson Square"
+                },
+                {
+                  "name": "Stony Brook"
+                },
+                {
+                  "name": "Green Street"
                 }
               ],
               "steps": [],
               "leg_geometry": {
                 "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
+                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@??jBdA|@f@f@Zx@h@fDhBHFnFvCbAl@xC`B|BrAxA~@zClBrA|@hBhANJj@d@NJPJlDtBl@^"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69575095",
+                "gtfs_id": "mbta-ma-us:69575303",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills",
                 "trip_short_name": null
               },
-              "distance": 5215.25,
+              "distance": 7967.24,
               "headsign": "Forest Hills",
-              "real_time": false
+              "real_time": true
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:54:00-04:00",
+                "scheduled_time": "2025-08-05T15:54:30-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:55:01-04:00",
+                "scheduled_time": "2025-08-05T15:55:59-04:00",
                 "estimated": null
               },
               "to": {
-                "name": "Jackson Square",
+                "name": "Forest Hills",
                 "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:11531",
+                  "name": "Forest Hills",
+                  "url": "https://www.mbta.com/stops/place-forhl",
+                  "gtfs_id": "mbta-ma-us:875",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                    "gtfs_id": "mbta-ma-us:place-forhl"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
+                "lat": 42.300479,
+                "lon": -71.113634
               },
               "from": {
-                "name": "Jackson Square",
+                "name": "Forest Hills",
                 "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:70006",
+                  "name": "Forest Hills",
+                  "url": "https://www.mbta.com/stops/place-forhl",
+                  "gtfs_id": "mbta-ma-us:70001",
                   "vehicle_mode": "SUBWAY",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "RapidTransit",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                    "gtfs_id": "mbta-ma-us:place-forhl"
                   }
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
+                "lat": 42.300926,
+                "lon": -71.114129
               },
-              "duration": 61.0,
-              "realtime_state": null,
+              "duration": 89.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
+                  "distance": 9.75,
+                  "absolute_direction": "EAST",
                   "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
+                  "street_name": "Buses, Parking, Lobby, Commuter Rail"
                 },
                 {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "CONTINUE",
+                  "distance": 71.58,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "HARD_RIGHT",
                   "street_name": "pathway"
                 },
                 {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
+                  "distance": 36.12,
+                  "absolute_direction": "SOUTH",
                   "relative_direction": "FOLLOW_SIGNS",
                   "street_name": "Buses"
                 }
               ],
               "leg_geometry": {
                 "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
+                "points": "w{daGhn`qLCSPJTC??X{@MYOIx@H"
               },
               "trip": null,
-              "distance": 71.02,
+              "distance": 117.46,
               "headsign": null,
               "real_time": false
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:00:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T16:00:00-04:00",
+                  "delay": "PT0S"
+                }
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-07-16T13:05:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-08-05T16:06:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T16:07:06-04:00",
+                  "delay": "PT1M6S"
+                }
               },
               "to": {
-                "name": "Humboldt Ave @ Seaver St",
+                "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
                 "stop": {
-                  "name": "Humboldt Ave @ Seaver St",
-                  "url": "https://www.mbta.com/stops/1325",
-                  "gtfs_id": "mbta-ma-us:1325",
+                  "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
+                  "url": "https://www.mbta.com/stops/2922",
+                  "gtfs_id": "mbta-ma-us:2922",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
                   "parent_station": null
                 },
-                "lat": 42.31045,
-                "lon": -71.091588
+                "lat": 42.301806,
+                "lon": -71.086667
               },
               "from": {
-                "name": "Jackson Square",
+                "name": "Forest Hills",
                 "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:11531",
+                  "name": "Forest Hills",
+                  "url": "https://www.mbta.com/stops/place-forhl",
+                  "gtfs_id": "mbta-ma-us:875",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                    "gtfs_id": "mbta-ma-us:place-forhl"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
+                "lat": 42.300479,
+                "lon": -71.113634
               },
-              "duration": 300.0,
-              "realtime_state": null,
+              "duration": 426.0,
               "transit_leg": true,
               "route": {
                 "type": 3,
                 "mode": "BUS",
                 "desc": "Local Bus",
                 "color": "FFC72C",
-                "sort_order": 50440,
-                "gtfs_id": "mbta-ma-us:44",
+                "gtfs_id": "mbta-ma-us:16",
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": "44",
-                "long_name": "Jackson Square Station - Ruggles Station",
-                "text_color": "000000"
+                "short_name": "16",
+                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                "text_color": "000000",
+                "sort_order": 50160
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
-                  "name": "Columbus Ave @ Dimock St"
+                  "name": "Arborway @ Courthouse"
                 },
                 {
-                  "name": "Columbus Ave opp Bray St"
+                  "name": "Circuit Dr @ Shattuck Hospital"
                 },
                 {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
-                },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
-                },
-                {
-                  "name": "Seaver St opp Harold St"
+                  "name": "Circuit Dr @ Glen Ln"
                 }
               ],
               "steps": [],
               "leg_geometry": {
                 "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBQS}@s@k@e@"
+                "points": "wxdaGtj`qLj@XR?Vc@w@a@wA_Ak@a@oAq@?c@Ao@K{CCqCDaG???IBkAH}@Fi@Pu@TaApB_FQUc@o@KQIQCSUkAQaBG{BBkADm@RuA^sBDg@@[Ae@?K????CWGYQUOMUKoBe@]Q{@s@[]uAiBo@kAs@cBm@wAu@kBUaAQ}A[wBUqAq@uCYgAQc@_@s@Q[_@}@Oi@AM??Iq@Ao@@cA@WNcATgAVaA`@}@r@qAZa@f@e@b@YnBiAv@a@`@U`@]v@aAd@}@^aARw@Nq@N}@Bq@?c@Ei@Gq@Uy@Qq@CUBSHQT_@Pe@Da@"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69703518",
+                "gtfs_id": "mbta-ma-us:69703224",
                 "direction_id": "1",
-                "trip_headsign": "Ruggles",
+                "trip_headsign": "Harbor Point via South Bay Center",
                 "trip_short_name": null
               },
-              "distance": 1832.48,
-              "headsign": "Ruggles",
-              "real_time": false
+              "distance": 2795.48,
+              "headsign": "Harbor Point via South Bay Center",
+              "real_time": true
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:05:00-04:00",
+                "scheduled_time": "2025-08-05T16:07:06-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:16:29-04:00",
+                "scheduled_time": "2025-08-05T16:15:08-04:00",
                 "estimated": null
               },
               "to": {
@@ -495,85 +495,67 @@
                 "lon": -71.090434
               },
               "from": {
-                "name": "Humboldt Ave @ Seaver St",
+                "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
                 "stop": {
-                  "name": "Humboldt Ave @ Seaver St",
-                  "url": "https://www.mbta.com/stops/1325",
-                  "gtfs_id": "mbta-ma-us:1325",
+                  "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
+                  "url": "https://www.mbta.com/stops/2922",
+                  "gtfs_id": "mbta-ma-us:2922",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
                   "parent_station": null
                 },
-                "lat": 42.31045,
-                "lon": -71.091588
+                "lat": 42.301806,
+                "lon": -71.086667
               },
-              "duration": 689.0,
-              "realtime_state": null,
+              "duration": 482.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
-                  "distance": 56.06,
-                  "absolute_direction": "SOUTHWEST",
+                  "distance": 4.43,
+                  "absolute_direction": "WEST",
                   "relative_direction": "DEPART",
-                  "street_name": "Humboldt Avenue"
-                },
-                {
-                  "distance": 17.46,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
                   "street_name": "path"
                 },
                 {
-                  "distance": 22.54,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 50.64,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "bike path"
-                },
-                {
-                  "distance": 237.9,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
+                  "distance": 9.92,
+                  "absolute_direction": "NORTH",
                   "relative_direction": "RIGHT",
                   "street_name": "service road"
                 },
                 {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
+                  "distance": 41.18,
+                  "absolute_direction": "WEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Franklin Park Road"
                 },
                 {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
+                  "distance": 40.89,
+                  "absolute_direction": "NORTHWEST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "road"
+                },
+                {
+                  "distance": 15.78,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "Franklin Park Road"
+                },
+                {
+                  "distance": 80.48,
+                  "absolute_direction": "NORTH",
                   "relative_direction": "LEFT",
-                  "street_name": "open area"
+                  "street_name": "path"
+                },
+                {
+                  "distance": 387.0,
+                  "absolute_direction": "NORTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "service road"
                 },
                 {
                   "distance": 4.18,
@@ -584,38 +566,527 @@
               ],
               "leg_geometry": {
                 "length": null,
-                "points": "iwfaGla|pLCJb@\\b@\\FFDBFKHAFC@BHJFLFHFCBEZc@JNDBD@F?@E@GBER]r@u@NQTQp@S\\GTBTHPHRN^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
+                "points": "gaeaGtb{pL@FAHQE?BCJCJEJEJO`@KJEDEBE@C?C?ECECCGGIO_@MDGDGBi@l@SVKSACEIIRc@d@[\\a@`@GHaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
               },
               "trip": null,
-              "distance": 747.94,
+              "distance": 583.84,
               "headsign": null,
               "real_time": false
             }
           ],
-          "accessibility_score": null
+          "generalized_cost": 8360,
+          "duration": 3657,
+          "number_of_transfers": 2,
+          "walk_distance": 969.53
         },
         {
-          "start": "2025-07-16T12:15:12-04:00",
-          "end": "2025-07-16T13:22:25-04:00",
-          "duration": 4033,
-          "generalized_cost": 7806,
-          "walk_distance": 879.0999999999999,
-          "number_of_transfers": 1,
+          "start": "2025-08-05T15:14:11-04:00",
+          "end": "2025-08-05T16:16:00-04:00",
+          "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:04:00-04:00",
+                "scheduled_time": "2025-08-05T15:15:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T12:17:01-04:00",
-                  "delay": "PT13M1S"
+                  "time": "2025-08-05T15:16:00-04:00",
+                  "delay": "PT1M"
                 }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:42:00-04:00",
+                "scheduled_time": "2025-08-05T15:41:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T12:55:41-04:00",
-                  "delay": "PT13M41S"
+                  "time": "2025-08-05T15:38:57-04:00",
+                  "delay": "-PT2M3S"
+                }
+              },
+              "to": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.330154,
+                "lon": -71.057655
+              },
+              "from": {
+                "name": "Alewife",
+                "stop": {
+                  "name": "Alewife",
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  }
+                },
+                "lat": 42.396148,
+                "lon": -71.140698
+              },
+              "duration": 1377.0,
+              "transit_leg": true,
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "DA291C",
+                "gtfs_id": "mbta-ma-us:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Red Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10010
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "UPDATED",
+              "intermediate_stops": [
+                {
+                  "name": "Davis"
+                },
+                {
+                  "name": "Porter"
+                },
+                {
+                  "name": "Harvard"
+                },
+                {
+                  "name": "Central"
+                },
+                {
+                  "name": "Kendall/MIT"
+                },
+                {
+                  "name": "Charles/MGH"
+                },
+                {
+                  "name": "Park Street"
+                },
+                {
+                  "name": "Downtown Crossing"
+                },
+                {
+                  "name": "South Station"
+                },
+                {
+                  "name": "Broadway"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:69349312",
+                "direction_id": "0",
+                "trip_headsign": "Ashmont",
+                "trip_short_name": null
+              },
+              "distance": 13074.0,
+              "headsign": "Ashmont",
+              "real_time": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:38:57-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T15:39:47-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:13",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.329962,
+                "lon": -71.057625
+              },
+              "from": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.330154,
+                "lon": -71.057655
+              },
+              "duration": 50.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 20.12,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to street and buses"
+                },
+                {
+                  "distance": 23.89,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Buses"
+                },
+                {
+                  "distance": 12.19,
+                  "absolute_direction": "EAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Buses"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "mrjaGjmupL??\\h@Fo@"
+              },
+              "trip": null,
+              "distance": 56.2,
+              "headsign": null,
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:48:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:48:00-04:00",
+                  "delay": "PT0S"
+                }
+              },
+              "mode": "BUS",
+              "end": {
+                "scheduled_time": "2025-08-05T15:56:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:54:04-04:00",
+                  "delay": "-PT1M56S"
+                }
+              },
+              "to": {
+                "name": "Columbia Rd @ Dudley St",
+                "stop": {
+                  "name": "Columbia Rd @ Dudley St",
+                  "url": "https://www.mbta.com/stops/2910",
+                  "gtfs_id": "mbta-ma-us:2910",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.317228,
+                "lon": -71.065045
+              },
+              "from": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us:13",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  }
+                },
+                "lat": 42.329962,
+                "lon": -71.057625
+              },
+              "duration": 364.0,
+              "transit_leg": true,
+              "route": {
+                "type": 3,
+                "mode": "BUS",
+                "desc": "Local Bus",
+                "color": "FFC72C",
+                "gtfs_id": "mbta-ma-us:17",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": "17",
+                "long_name": "Fields Corner Station - Andrew Station",
+                "text_color": "000000",
+                "sort_order": 50170
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "UPDATED",
+              "intermediate_stops": [
+                {
+                  "name": "Boston St @ Ellery St"
+                },
+                {
+                  "name": "Boston St opp Washburn St"
+                },
+                {
+                  "name": "Boston St @ W Howell St"
+                },
+                {
+                  "name": "Boston St opp Harvest St"
+                },
+                {
+                  "name": "Boston St opp Mayhew St"
+                },
+                {
+                  "name": "Columbia Rd @ Holden St"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@??RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J????lA\\\\LXJ??j@RVNRL`BfA~@l@????n@`@|@h@dAr@n@`@~@`@tA^XF????x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:69704311",
+                "direction_id": "0",
+                "trip_headsign": "Fields Corner",
+                "trip_short_name": null
+              },
+              "distance": 1679.14,
+              "headsign": "Fields Corner",
+              "real_time": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:58:12-04:00",
+                  "delay": "-PT1M48S"
+                }
+              },
+              "mode": "BUS",
+              "end": {
+                "scheduled_time": "2025-08-05T16:15:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T16:08:48-04:00",
+                  "delay": "-PT6M12S"
+                }
+              },
+              "to": {
+                "name": "Franklin Park Zoo @ Entrance",
+                "stop": {
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "url": "https://www.mbta.com/stops/1587",
+                  "gtfs_id": "mbta-ma-us:1587",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "NO_INFORMATION",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.303124,
+                "lon": -71.08595
+              },
+              "from": {
+                "name": "Columbia Rd @ Dudley St",
+                "stop": {
+                  "name": "Columbia Rd @ Dudley St",
+                  "url": "https://www.mbta.com/stops/2910",
+                  "gtfs_id": "mbta-ma-us:2910",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.317228,
+                "lon": -71.065045
+              },
+              "duration": 636.0,
+              "transit_leg": true,
+              "route": {
+                "type": 3,
+                "mode": "BUS",
+                "desc": "Local Bus",
+                "color": "FFC72C",
+                "gtfs_id": "mbta-ma-us:16",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": "16",
+                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                "text_color": "000000",
+                "sort_order": 50160
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "UPDATED",
+              "intermediate_stops": [
+                {
+                  "name": "Columbia Rd @ Bird St"
+                },
+                {
+                  "name": "Columbia Rd @ Glendale St"
+                },
+                {
+                  "name": "Columbia Rd @ Quincy St"
+                },
+                {
+                  "name": "Columbia Rd @ Hamilton St"
+                },
+                {
+                  "name": "Columbia Rd opp Wyola Pl"
+                },
+                {
+                  "name": "Columbia Rd @ Devon St"
+                },
+                {
+                  "name": "Columbia Rd @ Geneva Ave"
+                },
+                {
+                  "name": "Columbia Rd @ Washington St"
+                },
+                {
+                  "name": "Columbia Rd @ Seaver St"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "gahaGd{vpL??Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:69704698",
+                "direction_id": "0",
+                "trip_headsign": "Forest Hills via South Bay Center",
+                "trip_short_name": null
+              },
+              "distance": 2411.37,
+              "headsign": "Forest Hills via South Bay Center",
+              "real_time": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T16:08:48-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T16:16:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Franklin Park Zoo",
+                "stop": null,
+                "lat": 42.305067,
+                "lon": -71.090434
+              },
+              "from": {
+                "name": "Franklin Park Zoo @ Entrance",
+                "stop": {
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "url": "https://www.mbta.com/stops/1587",
+                  "gtfs_id": "mbta-ma-us:1587",
+                  "vehicle_mode": "BUS",
+                  "wheelchair_boarding": "NO_INFORMATION",
+                  "zone_id": "LocalBus",
+                  "parent_station": null
+                },
+                "lat": 42.303124,
+                "lon": -71.08595
+              },
+              "duration": 432.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 34.79,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "DEPART",
+                  "street_name": "Franklin Park Road"
+                },
+                {
+                  "distance": 13.01,
+                  "absolute_direction": "NORTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 51.01,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 417.83,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 4.18,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
+              },
+              "trip": null,
+              "distance": 520.79,
+              "headsign": null,
+              "real_time": false
+            }
+          ],
+          "generalized_cost": 7690,
+          "duration": 3709,
+          "number_of_transfers": 2,
+          "walk_distance": 715.0699999999999
+        },
+        {
+          "start": "2025-08-05T15:14:11-04:00",
+          "end": "2025-08-05T16:17:17-04:00",
+          "accessibility_score": null,
+          "legs": [
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:15:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:16:00-04:00",
+                  "delay": "PT1M"
+                }
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-08-05T15:54:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:50:27-04:00",
+                  "delay": "-PT3M33S"
                 }
               },
               "to": {
@@ -650,26 +1121,26 @@
                 "lat": 42.396148,
                 "lon": -71.140698
               },
-              "duration": 2320.0,
-              "realtime_state": null,
+              "duration": 2067.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
-                "sort_order": 10010,
                 "gtfs_id": "mbta-ma-us:Red",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Red Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10010
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
                   "name": "Davis"
@@ -723,7 +1194,7 @@
                 "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@??f@?j@TxF|BpBp@\\NNBV?|@[j@[l@g@~B}CTYn@kA~A}BZg@xDwF^c@l@q@VQdAu@\\Sl@Yj@U\\O~@YdAUvAORCt@EzAIPA??`BMXCjAGlAEt@Ev@E~@AdAAbCEnCC~BChCMr@?nBDxALjARdBd@pDbA~@XnBn@\\LPF~Al@NF??p@RbA^jA`@lAZf@R~@TvAX|@J~@NP?dBVxHhArDt@`@JXFvAVhALx@FbADtAA`BAx@BJBHBz@f@TL^^R\\h@jAN`@J\\H^F^LpADnA@dD@jD@x@B`@@r@HdAHd@Jl@H^VxA??VxA@Rl@tD^rAVn@Rb@`@z@\\l@b@l@n@r@l@j@l@h@n@`@hAf@n@\\t@RzANpACrBGrE{@zBa@tB_@??@AnOmBbOgBb@GrC[n@OdEmARAV?b@LJ@rCkA"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69349294",
+                "gtfs_id": "mbta-ma-us:69349312",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
@@ -734,12 +1205,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:55:41-04:00",
+                "scheduled_time": "2025-08-05T15:50:27-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:56:34-04:00",
+                "scheduled_time": "2025-08-05T15:51:23-04:00",
                 "estimated": null
               },
               "to": {
@@ -774,11 +1245,11 @@
                 "lat": 42.284508,
                 "lon": -71.063833
               },
-              "duration": 53.0,
-              "realtime_state": null,
+              "duration": 56.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -817,18 +1288,18 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:01:00-04:00",
+                "scheduled_time": "2025-08-05T15:56:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T13:01:00-04:00",
+                  "time": "2025-08-05T15:56:00-04:00",
                   "delay": "PT0S"
                 }
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-07-16T13:17:00-04:00",
+                "scheduled_time": "2025-08-05T16:15:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T13:12:11-04:00",
-                  "delay": "-PT4M49S"
+                  "time": "2025-08-05T16:07:34-04:00",
+                  "delay": "-PT7M26S"
                 }
               },
               "to": {
@@ -861,26 +1332,26 @@
                 "lat": 42.284195,
                 "lon": -71.063879
               },
-              "duration": 671.0,
-              "realtime_state": null,
+              "duration": 694.0,
               "transit_leg": true,
               "route": {
                 "type": 3,
                 "mode": "BUS",
                 "desc": "Frequent Bus",
                 "color": "FFC72C",
-                "sort_order": 50220,
                 "gtfs_id": "mbta-ma-us:22",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": "22",
                 "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
+                "text_color": "000000",
+                "sort_order": 50220
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
                   "name": "Talbot Ave @ Dorchester Ave"
@@ -925,7 +1396,7 @@
                 "points": "asaaGvtvpL}@`@a@`@Q\\]NiASyAY[G{@OQEAJKr@c@\\OFe@N????C@aCfAu@j@{@p@{AdBe@r@o@dA_@~@Qd@IV??a@lAm@~BEPI^YpAY|BKh@W|C??CZC|@IdB?lACT[xAa@rB????I`@o@fDa@dB]jBGV??]hBOr@}@vEo@`D?@??k@jCo@dDOr@??oAzGiA|FCL????_@fB[bBcAzEkAbGCP????s@pDMl@Sv@YhAoAWwA[????sDy@sEcAsAUuAY????WGeDy@wD}@[I????qCq@sBg@wD{@"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69702526",
+                "gtfs_id": "mbta-ma-us:69702554",
                 "direction_id": "1",
                 "trip_headsign": "Ruggles",
                 "trip_short_name": null
@@ -936,12 +1407,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:12:11-04:00",
+                "scheduled_time": "2025-08-05T16:07:34-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:22:25-04:00",
+                "scheduled_time": "2025-08-05T16:17:17-04:00",
                 "estimated": null
               },
               "to": {
@@ -964,11 +1435,11 @@
                 "lat": 42.302768,
                 "lon": -71.085185
               },
-              "duration": 614.0,
-              "realtime_state": null,
+              "duration": 583.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -1024,24 +1495,24 @@
               "real_time": false
             }
           ],
-          "accessibility_score": null
+          "generalized_cost": 7607,
+          "duration": 3786,
+          "number_of_transfers": 1,
+          "walk_distance": 879.0999999999999
         },
         {
-          "start": "2025-07-16T12:23:11-04:00",
-          "end": "2025-07-16T13:24:20-04:00",
-          "duration": 3669,
-          "generalized_cost": 8292,
-          "walk_distance": 947.36,
-          "number_of_transfers": 2,
+          "start": "2025-08-05T15:18:11-04:00",
+          "end": "2025-08-05T16:18:17-04:00",
+          "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:25:00-04:00",
+                "scheduled_time": "2025-08-05T15:20:00-04:00",
                 "estimated": null
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:44:00-04:00",
+                "scheduled_time": "2025-08-05T15:39:00-04:00",
                 "estimated": null
               },
               "to": {
@@ -1077,25 +1548,25 @@
                 "lon": -71.140698
               },
               "duration": 1140.0,
-              "realtime_state": null,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
-                "sort_order": 10010,
                 "gtfs_id": "mbta-ma-us:Red",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Red Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10010
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Davis"
@@ -1125,23 +1596,23 @@
                 "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69349296",
+                "gtfs_id": "mbta-ma-us:69349532",
                 "direction_id": "0",
-                "trip_headsign": "Ashmont",
+                "trip_headsign": "Braintree",
                 "trip_short_name": null
               },
               "distance": 9820.78,
-              "headsign": "Ashmont",
+              "headsign": "Braintree",
               "real_time": false
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:44:00-04:00",
+                "scheduled_time": "2025-08-05T15:39:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:45:47-04:00",
+                "scheduled_time": "2025-08-05T15:40:49-04:00",
                 "estimated": null
               },
               "to": {
@@ -1176,11 +1647,11 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 107.0,
-              "realtime_state": null,
+              "duration": 109.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -1219,13 +1690,19 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:49:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:45:11-04:00",
+                  "delay": "PT1M11S"
+                }
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T13:01:00-04:00",
-                "estimated": null
+                "scheduled_time": "2025-08-05T15:57:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:55:38-04:00",
+                  "delay": "-PT1M22S"
+                }
               },
               "to": {
                 "name": "Jackson Square",
@@ -1259,26 +1736,26 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 720.0,
-              "realtime_state": null,
+              "duration": 627.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "ED8B00",
-                "sort_order": 10020,
                 "gtfs_id": "mbta-ma-us:Orange",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Orange Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10020
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
                   "name": "Chinatown"
@@ -1305,23 +1782,23 @@
                 "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69575103",
+                "gtfs_id": "mbta-ma-us:69575153",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills",
                 "trip_short_name": null
               },
               "distance": 5215.25,
               "headsign": "Forest Hills",
-              "real_time": false
+              "real_time": true
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:01:00-04:00",
+                "scheduled_time": "2025-08-05T15:55:38-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:02:01-04:00",
+                "scheduled_time": "2025-08-05T15:56:42-04:00",
                 "estimated": null
               },
               "to": {
@@ -1356,11 +1833,11 @@
                 "lat": 42.323132,
                 "lon": -71.099592
               },
-              "duration": 61.0,
-              "realtime_state": null,
+              "duration": 64.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -1405,18 +1882,18 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:11:00-04:00",
+                "scheduled_time": "2025-08-05T16:07:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T13:07:03-04:00",
-                  "delay": "-PT3M57S"
+                  "time": "2025-08-05T16:01:58-04:00",
+                  "delay": "-PT5M2S"
                 }
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-07-16T13:19:00-04:00",
+                "scheduled_time": "2025-08-05T16:17:00-04:00",
                 "estimated": {
-                  "time": "2025-07-16T13:15:48-04:00",
-                  "delay": "-PT3M12S"
+                  "time": "2025-08-05T16:10:13-04:00",
+                  "delay": "-PT6M47S"
                 }
               },
               "to": {
@@ -1449,26 +1926,26 @@
                 "lat": 42.323074,
                 "lon": -71.099546
               },
-              "duration": 525.0,
-              "realtime_state": null,
+              "duration": 495.0,
               "transit_leg": true,
               "route": {
                 "type": 3,
                 "mode": "BUS",
                 "desc": "Frequent Bus",
                 "color": "FFC72C",
-                "sort_order": 50220,
                 "gtfs_id": "mbta-ma-us:22",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": "22",
                 "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
+                "text_color": "000000",
+                "sort_order": 50220
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "UPDATED",
               "intermediate_stops": [
                 {
                   "name": "Columbus Ave @ Dimock St"
@@ -1495,7 +1972,7 @@
                 "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69703873",
+                "gtfs_id": "mbta-ma-us:69699370",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
@@ -1506,12 +1983,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:15:48-04:00",
+                "scheduled_time": "2025-08-05T16:10:13-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:24:20-04:00",
+                "scheduled_time": "2025-08-05T16:18:17-04:00",
                 "estimated": null
               },
               "to": {
@@ -1534,11 +2011,11 @@
                 "lat": 42.307515,
                 "lon": -71.089263
               },
-              "duration": 512.0,
-              "realtime_state": null,
+              "duration": 484.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -1594,47 +2071,41 @@
               "real_time": false
             }
           ],
-          "accessibility_score": null
+          "generalized_cost": 8278,
+          "duration": 3606,
+          "number_of_transfers": 2,
+          "walk_distance": 947.36
         },
         {
-          "start": "2025-07-16T12:19:40-04:00",
-          "end": "2025-07-16T13:25:33-04:00",
-          "duration": 3953,
-          "generalized_cost": 7903,
-          "walk_distance": 715.0699999999999,
-          "number_of_transfers": 2,
+          "start": "2025-08-05T15:18:11-04:00",
+          "end": "2025-08-05T16:23:35-04:00",
+          "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:15:00-04:00",
-                "estimated": {
-                  "time": "2025-07-16T12:21:29-04:00",
-                  "delay": "PT6M29S"
-                }
+                "scheduled_time": "2025-08-05T15:20:00-04:00",
+                "estimated": null
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:40:00-04:00",
-                "estimated": {
-                  "time": "2025-07-16T12:47:03-04:00",
-                  "delay": "PT7M3S"
-                }
+                "scheduled_time": "2025-08-05T15:39:00-04:00",
+                "estimated": null
               },
               "to": {
-                "name": "Andrew",
+                "name": "Downtown Crossing",
                 "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:70083",
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
                   "vehicle_mode": "SUBWAY",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "RapidTransit",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
                   }
                 },
-                "lat": 42.330154,
-                "lon": -71.057655
+                "lat": 42.355518,
+                "lon": -71.060225
               },
               "from": {
                 "name": "Alewife",
@@ -1652,26 +2123,907 @@
                 "lat": 42.396148,
                 "lon": -71.140698
               },
-              "duration": 1534.0,
-              "realtime_state": null,
+              "duration": 1140.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
-                "sort_order": 10010,
                 "gtfs_id": "mbta-ma-us:Red",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Red Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10010
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
+              "intermediate_stops": [
+                {
+                  "name": "Davis"
+                },
+                {
+                  "name": "Porter"
+                },
+                {
+                  "name": "Harvard"
+                },
+                {
+                  "name": "Central"
+                },
+                {
+                  "name": "Kendall/MIT"
+                },
+                {
+                  "name": "Charles/MGH"
+                },
+                {
+                  "name": "Park Street"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:69349532",
+                "direction_id": "0",
+                "trip_headsign": "Braintree",
+                "trip_short_name": null
+              },
+              "distance": 9820.78,
+              "headsign": "Braintree",
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:39:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T15:40:49-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "from": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "duration": 109.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 36.12,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Concourse | CharlieCard Store"
+                },
+                {
+                  "distance": 77.57,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                },
+                {
+                  "distance": 16.46,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "}poaGl}upL????????"
+              },
+              "trip": null,
+              "distance": 130.15,
+              "headsign": null,
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:45:11-04:00",
+                  "delay": "PT1M11S"
+                }
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
+                "estimated": {
+                  "time": "2025-08-05T15:58:21-04:00",
+                  "delay": "-PT1M39S"
+                }
+              },
+              "to": {
+                "name": "Green Street",
+                "stop": {
+                  "name": "Green Street",
+                  "url": "https://www.mbta.com/stops/place-grnst",
+                  "gtfs_id": "mbta-ma-us:70002",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-grnst"
+                  }
+                },
+                "lat": 42.309832,
+                "lon": -71.108059
+              },
+              "from": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "duration": 790.0,
+              "transit_leg": true,
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "ED8B00",
+                "gtfs_id": "mbta-ma-us:Orange",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Orange Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10020
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "UPDATED",
+              "intermediate_stops": [
+                {
+                  "name": "Chinatown"
+                },
+                {
+                  "name": "Tufts Medical Center"
+                },
+                {
+                  "name": "Back Bay"
+                },
+                {
+                  "name": "Massachusetts Avenue"
+                },
+                {
+                  "name": "Ruggles"
+                },
+                {
+                  "name": "Roxbury Crossing"
+                },
+                {
+                  "name": "Jackson Square"
+                },
+                {
+                  "name": "Stony Brook"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us:69575153",
+                "direction_id": "0",
+                "trip_headsign": "Forest Hills",
+                "trip_short_name": null
+              },
+              "distance": 6857.3,
+              "headsign": "Forest Hills",
+              "real_time": true
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:58:21-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T16:23:35-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Franklin Park Zoo",
+                "stop": null,
+                "lat": 42.305067,
+                "lon": -71.090434
+              },
+              "from": {
+                "name": "Green Street",
+                "stop": {
+                  "name": "Green Street",
+                  "url": "https://www.mbta.com/stops/place-grnst",
+                  "gtfs_id": "mbta-ma-us:70002",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us:place-grnst"
+                  }
+                },
+                "lat": 42.309832,
+                "lon": -71.108059
+              },
+              "duration": 1514.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 67.67,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to street"
+                },
+                {
+                  "distance": 19.37,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "pathway"
+                },
+                {
+                  "distance": 11.89,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "EXIT_STATION",
+                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
+                },
+                {
+                  "distance": 170.33,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "sidewalk"
+                },
+                {
+                  "distance": 5.09,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Union Avenue"
+                },
+                {
+                  "distance": 102.98,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "Green Street"
+                },
+                {
+                  "distance": 420.06,
+                  "absolute_direction": "EAST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "Glen Road"
+                },
+                {
+                  "distance": 318.77,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "SLIGHTLY_RIGHT",
+                  "street_name": "Glen Lane"
+                },
+                {
+                  "distance": 155.39,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "bike path"
+                },
+                {
+                  "distance": 294.71,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Pierpont Road"
+                },
+                {
+                  "distance": 42.5,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 57.09,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "SLIGHTLY_LEFT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 89.98,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "RIGHT",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 12.65,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 156.98,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 4.18,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
+              },
+              "trip": null,
+              "distance": 1929.63,
+              "headsign": null,
+              "real_time": false
+            }
+          ],
+          "generalized_cost": 11721,
+          "duration": 3924,
+          "number_of_transfers": 1,
+          "walk_distance": 2197.86
+        }
+      ],
+      "search_date_time": "2025-08-05T15:11:24-04:00"
+    },
+    "ideal_plan": {
+      "routing_errors": [],
+      "itineraries": [
+        {
+          "start": "2025-08-05T15:13:11-04:00",
+          "end": "2025-08-05T16:18:48-04:00",
+          "accessibility_score": null,
+          "legs": [
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:15:00-04:00",
+                "estimated": null
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-08-05T15:36:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "South Station",
+                "stop": {
+                  "name": "South Station",
+                  "url": "https://www.mbta.com/stops/place-sstat",
+                  "gtfs_id": "mbta-ma-us-initial:70079",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                  }
+                },
+                "lat": 42.352271,
+                "lon": -71.055242
+              },
+              "from": {
+                "name": "Alewife",
+                "stop": {
+                  "name": "Alewife",
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us-initial:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                  }
+                },
+                "lat": 42.396148,
+                "lon": -71.140698
+              },
+              "duration": 1260.0,
+              "transit_leg": true,
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "DA291C",
+                "gtfs_id": "mbta-ma-us-initial:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Red Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10010
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "SCHEDULED",
+              "intermediate_stops": [
+                {
+                  "name": "Davis"
+                },
+                {
+                  "name": "Porter"
+                },
+                {
+                  "name": "Harvard"
+                },
+                {
+                  "name": "Central"
+                },
+                {
+                  "name": "Kendall/MIT"
+                },
+                {
+                  "name": "Charles/MGH"
+                },
+                {
+                  "name": "Park Street"
+                },
+                {
+                  "name": "Downtown Crossing"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us-initial:69349312",
+                "direction_id": "0",
+                "trip_headsign": "Ashmont",
+                "trip_short_name": null
+              },
+              "distance": 10360.26,
+              "headsign": "Ashmont",
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:36:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T15:39:25-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "South Station",
+                "stop": {
+                  "name": "South Station",
+                  "url": "https://www.mbta.com/stops/place-sstat",
+                  "gtfs_id": "mbta-ma-us-initial:NEC-2287",
+                  "vehicle_mode": "RAIL",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "CR-zone-1A",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                  }
+                },
+                "lat": 42.35141,
+                "lon": -71.055417
+              },
+              "from": {
+                "name": "South Station",
+                "stop": {
+                  "name": "South Station",
+                  "url": "https://www.mbta.com/stops/place-sstat",
+                  "gtfs_id": "mbta-ma-us-initial:70079",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                  }
+                },
+                "lat": 42.352271,
+                "lon": -71.055242
+              },
+              "duration": 205.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 47.85,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Silver Line - SL4 Nubian, lobby, Amtrak, Commuter Rail"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit-only gates"
+                },
+                {
+                  "distance": 6.1,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Bus Terminal, lobby, Amtrak, Silver Line - SL4 Nubian, Commuter Rail"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit"
+                },
+                {
+                  "distance": 33.83,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Silver Line Nubian / Bus Terminal / Commuter Rail"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Commuter Rail, concourse"
+                },
+                {
+                  "distance": 23.77,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Commuter Rail, concourse"
+                },
+                {
+                  "distance": 127.66,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Commuter Rail - All trains"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "u|naGh~tpL??????????????jD`@"
+              },
+              "trip": null,
+              "distance": 239.22,
+              "headsign": null,
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:47:00-04:00",
+                "estimated": null
+              },
+              "mode": "RAIL",
+              "end": {
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Four Corners/Geneva",
+                "stop": {
+                  "name": "Four Corners/Geneva",
+                  "url": "https://www.mbta.com/stops/place-DB-2249",
+                  "gtfs_id": "mbta-ma-us-initial:DB-2249-01",
+                  "vehicle_mode": "RAIL",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "CR-zone-1A",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-DB-2249"
+                  }
+                },
+                "lat": 42.303955,
+                "lon": -71.077979
+              },
+              "from": {
+                "name": "South Station",
+                "stop": {
+                  "name": "South Station",
+                  "url": "https://www.mbta.com/stops/place-sstat",
+                  "gtfs_id": "mbta-ma-us-initial:NEC-2287",
+                  "vehicle_mode": "RAIL",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "CR-zone-1A",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                  }
+                },
+                "lat": 42.35141,
+                "lon": -71.055417
+              },
+              "duration": 780.0,
+              "transit_leg": true,
+              "route": {
+                "type": 2,
+                "mode": "RAIL",
+                "desc": "Regional Rail",
+                "color": "80276C",
+                "gtfs_id": "mbta-ma-us-initial:CR-Fairmount",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Fairmount Line",
+                "text_color": "FFFFFF",
+                "sort_order": 20001
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "SCHEDULED",
+              "intermediate_stops": [
+                {
+                  "name": "Newmarket"
+                },
+                {
+                  "name": "Uphams Corner"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "kvnaGd|tpL|KxEr@XpDbBl@Zh@\\t@^hAp@fBfAvDzBvEnCFFHDJHjBdApAv@tAf@p@Nj@NLDPFR@b@@V?~@Av@A`AAhAAnDK|DGdHMxBEXDp@N`@Nh@XrAt@|A~@NJlE|BhBfAlAl@zAx@n@Z`@Rb@Rz@f@`@TbB~@f@T|@j@jCtAhFtCfCtA`B|@??nCxApAp@JFXL|B`AtAd@dAVnAVpAVtBZdATjGfAbANpEv@rARdCb@??HBfANXD`Et@F@`BZxA\\v@ThA^`Ab@tAh@fGbC~Al@PFFBZJtAh@fBt@`A^`C`AtCfAfA^~@`@bA`@\\LdChA|@f@v@d@`At@~@|@v@z@z@dAjBxBbCvCxA`Bx@bAr@t@v@v@v@l@FDLH"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us-initial:SPRING2025V2-715709-1661",
+                "direction_id": "0",
+                "trip_headsign": "Readville",
+                "trip_short_name": "1661"
+              },
+              "distance": 5686.15,
+              "headsign": "Readville via Fairmount",
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T16:18:48-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Franklin Park Zoo",
+                "stop": null,
+                "lat": 42.305067,
+                "lon": -71.090434
+              },
+              "from": {
+                "name": "Four Corners/Geneva",
+                "stop": {
+                  "name": "Four Corners/Geneva",
+                  "url": "https://www.mbta.com/stops/place-DB-2249",
+                  "gtfs_id": "mbta-ma-us-initial:DB-2249-01",
+                  "vehicle_mode": "RAIL",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "CR-zone-1A",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-DB-2249"
+                  }
+                },
+                "lat": 42.303955,
+                "lon": -71.077979
+              },
+              "duration": 1128.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 82.3,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "DEPART",
+                  "street_name": "Track 1 (Outbound)"
+                },
+                {
+                  "distance": 40.6,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "SLIGHTLY_RIGHT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 3.74,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Washington Street"
+                },
+                {
+                  "distance": 223.95,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "Erie Street"
+                },
+                {
+                  "distance": 230.12,
+                  "absolute_direction": "NORTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "Hewins Street"
+                },
+                {
+                  "distance": 206.83,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Columbia Road"
+                },
+                {
+                  "distance": 100.28,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Franklin Park Road"
+                },
+                {
+                  "distance": 13.01,
+                  "absolute_direction": "NORTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 51.01,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 417.83,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "LEFT",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 4.18,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "speaG|jypL~BbB?BTt@HGHJDCPJRPNRVp@ZpAp@|Bx@lCq@fA_BpCaAbBy@rAGLNXJ`@FPDPBRBLBP@N?N@P?RA^@R?H?P?T?V@\\?f@@\\?HAHAFCFDLBD@D@Bv@`Bf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
+              },
+              "trip": null,
+              "distance": 1373.83,
+              "headsign": null,
+              "real_time": false
+            }
+          ],
+          "generalized_cost": 10432,
+          "duration": 3937,
+          "number_of_transfers": 1,
+          "walk_distance": 1751.1299999999999
+        },
+        {
+          "start": "2025-08-05T15:13:11-04:00",
+          "end": "2025-08-05T16:22:12-04:00",
+          "accessibility_score": null,
+          "legs": [
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:15:00-04:00",
+                "estimated": null
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-08-05T15:41:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Andrew",
+                "stop": {
+                  "name": "Andrew",
+                  "url": "https://www.mbta.com/stops/place-andrw",
+                  "gtfs_id": "mbta-ma-us-initial:70083",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                  }
+                },
+                "lat": 42.330154,
+                "lon": -71.057655
+              },
+              "from": {
+                "name": "Alewife",
+                "stop": {
+                  "name": "Alewife",
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us-initial:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                  }
+                },
+                "lat": 42.396148,
+                "lon": -71.140698
+              },
+              "duration": 1560.0,
+              "transit_leg": true,
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "DA291C",
+                "gtfs_id": "mbta-ma-us-initial:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Red Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10010
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Davis"
@@ -1710,23 +3062,23 @@
                 "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69349295",
+                "gtfs_id": "mbta-ma-us-initial:69349312",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
               },
               "distance": 13074.0,
               "headsign": "Ashmont",
-              "real_time": true
+              "real_time": false
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:47:03-04:00",
+                "scheduled_time": "2025-08-05T15:41:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:47:52-04:00",
+                "scheduled_time": "2025-08-05T15:41:50-04:00",
                 "estimated": null
               },
               "to": {
@@ -1734,12 +3086,12 @@
                 "stop": {
                   "name": "Andrew",
                   "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:13",
+                  "gtfs_id": "mbta-ma-us-initial:13",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
+                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
                   }
                 },
                 "lat": 42.329962,
@@ -1750,22 +3102,22 @@
                 "stop": {
                   "name": "Andrew",
                   "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:70083",
+                  "gtfs_id": "mbta-ma-us-initial:70083",
                   "vehicle_mode": "SUBWAY",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "RapidTransit",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
+                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
                   }
                 },
                 "lat": 42.330154,
                 "lon": -71.057655
               },
-              "duration": 49.0,
-              "realtime_state": null,
+              "duration": 50.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -1798,26 +3150,20 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:55:00-04:00",
-                "estimated": {
-                  "time": "2025-07-16T12:55:00-04:00",
-                  "delay": "PT0S"
-                }
+                "scheduled_time": "2025-08-05T15:48:00-04:00",
+                "estimated": null
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-07-16T12:58:00-04:00",
-                "estimated": {
-                  "time": "2025-07-16T13:00:16-04:00",
-                  "delay": "PT2M16S"
-                }
+                "scheduled_time": "2025-08-05T15:53:00-04:00",
+                "estimated": null
               },
               "to": {
                 "name": "Columbia Rd @ Holden St",
                 "stop": {
                   "name": "Columbia Rd @ Holden St",
                   "url": "https://www.mbta.com/stops/362",
-                  "gtfs_id": "mbta-ma-us:362",
+                  "gtfs_id": "mbta-ma-us-initial:362",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
@@ -1831,37 +3177,37 @@
                 "stop": {
                   "name": "Andrew",
                   "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:13",
+                  "gtfs_id": "mbta-ma-us-initial:13",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
+                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
                   }
                 },
                 "lat": 42.329962,
                 "lon": -71.057625
               },
-              "duration": 316.0,
-              "realtime_state": null,
+              "duration": 300.0,
               "transit_leg": true,
               "route": {
                 "type": 3,
                 "mode": "BUS",
                 "desc": "Local Bus",
                 "color": "FFC72C",
-                "sort_order": 50170,
-                "gtfs_id": "mbta-ma-us:17",
+                "gtfs_id": "mbta-ma-us-initial:17",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": "17",
                 "long_name": "Fields Corner Station - Andrew Station",
-                "text_color": "000000"
+                "text_color": "000000",
+                "sort_order": 50170
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Boston St @ Ellery St"
@@ -1885,23 +3231,23 @@
                 "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@??RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J????lA\\\\LXJ??j@RVNRL`BfA~@l@????n@`@|@h@dAr@n@`@~@`@tA^XF????x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69704772",
+                "gtfs_id": "mbta-ma-us-initial:69704311",
                 "direction_id": "0",
                 "trip_headsign": "Fields Corner",
                 "trip_short_name": null
               },
               "distance": 1463.0,
               "headsign": "Fields Corner",
-              "real_time": true
+              "real_time": false
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:04:00-04:00",
+                "scheduled_time": "2025-08-05T15:59:00-04:00",
                 "estimated": null
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-07-16T13:18:00-04:00",
+                "scheduled_time": "2025-08-05T16:15:00-04:00",
                 "estimated": null
               },
               "to": {
@@ -1909,7 +3255,7 @@
                 "stop": {
                   "name": "Franklin Park Zoo @ Entrance",
                   "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us:1587",
+                  "gtfs_id": "mbta-ma-us-initial:1587",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "NO_INFORMATION",
                   "zone_id": "LocalBus",
@@ -1923,7 +3269,7 @@
                 "stop": {
                   "name": "Columbia Rd @ Holden St",
                   "url": "https://www.mbta.com/stops/362",
-                  "gtfs_id": "mbta-ma-us:362",
+                  "gtfs_id": "mbta-ma-us-initial:362",
                   "vehicle_mode": "BUS",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "LocalBus",
@@ -1932,26 +3278,26 @@
                 "lat": 42.318764,
                 "lon": -71.063583
               },
-              "duration": 840.0,
-              "realtime_state": null,
+              "duration": 960.0,
               "transit_leg": true,
               "route": {
                 "type": 3,
                 "mode": "BUS",
                 "desc": "Local Bus",
                 "color": "FFC72C",
-                "sort_order": 50160,
-                "gtfs_id": "mbta-ma-us:16",
+                "gtfs_id": "mbta-ma-us-initial:16",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": "16",
                 "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000"
+                "text_color": "000000",
+                "sort_order": 50160
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Columbia Rd @ Dudley St"
@@ -1990,7 +3336,7 @@
                 "points": "_khaGxqvpL??VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us:69703644",
+                "gtfs_id": "mbta-ma-us-initial:69704698",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills via South Bay Center",
                 "trip_short_name": null
@@ -2001,823 +3347,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:18:00-04:00",
+                "scheduled_time": "2025-08-05T16:15:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:25:33-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "duration": 453.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 34.79,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Franklin Park Road"
-                },
-                {
-                  "distance": 13.01,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 51.01,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "trip": null,
-              "distance": 520.79,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-07-16T12:18:11-04:00",
-          "end": "2025-07-16T13:25:48-04:00",
-          "duration": 4057,
-          "generalized_cost": 7407,
-          "walk_distance": 715.0699999999999,
-          "number_of_transfers": 1,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:20:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-07-16T12:45:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1.5e3,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                },
-                {
-                  "name": "Downtown Crossing"
-                },
-                {
-                  "name": "South Station"
-                },
-                {
-                  "name": "Broadway"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69349515",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 13074.0,
-              "headsign": "Braintree",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:45:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T12:45:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "duration": 49.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 20.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 23.89,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "mrjaGjmupL??\\h@Fo@"
-              },
-              "trip": null,
-              "distance": 56.2,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:51:00-04:00",
-                "estimated": {
-                  "time": "2025-07-16T12:52:12-04:00",
-                  "delay": "PT1M12S"
-                }
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-07-16T13:18:00-04:00",
-                "estimated": {
-                  "time": "2025-07-16T13:18:15-04:00",
-                  "delay": "PT15S"
-                }
-              },
-              "to": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "duration": 1563.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "sort_order": 50160,
-                "gtfs_id": "mbta-ma-us:16",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "16",
-                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "South Bay Mall @ Target"
-                },
-                {
-                  "name": "South Bay Mall opp Macy's"
-                },
-                {
-                  "name": "South Bay Mall @ Allstate Rd"
-                },
-                {
-                  "name": "Massachusetts Ave opp Clapp St"
-                },
-                {
-                  "name": "Massachusetts Ave @ Columbia Rd"
-                },
-                {
-                  "name": "Columbia Rd @ Holden St"
-                },
-                {
-                  "name": "Columbia Rd @ Dudley St"
-                },
-                {
-                  "name": "Columbia Rd @ Bird St"
-                },
-                {
-                  "name": "Columbia Rd @ Glendale St"
-                },
-                {
-                  "name": "Columbia Rd @ Quincy St"
-                },
-                {
-                  "name": "Columbia Rd @ Hamilton St"
-                },
-                {
-                  "name": "Columbia Rd opp Wyola Pl"
-                },
-                {
-                  "name": "Columbia Rd @ Devon St"
-                },
-                {
-                  "name": "Columbia Rd @ Geneva Ave"
-                },
-                {
-                  "name": "Columbia Rd @ Washington St"
-                },
-                {
-                  "name": "Columbia Rd @ Seaver St"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "arjaGdmupL?cCd@An@?`@Jm@tFm@jECR[hDWnBQ~ASbBAFg@lEET?VJRHPb@FNCHIHEDKBQ?iAA[?????Y@e@Dg@FSFOLQb@c@bB}ATQPGLAP?RBVFTHhFbCz@b@????tCzAXP\\RFD??FD^t@FPBPCXGn@T?NDRPh@nAHn@j@tAt@tBJIj@_@hByAn@g@r@o@JI??jAeAfEgD|BgBrAeA????~@s@X[NUD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69703644",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills via South Bay Center",
-                "trip_short_name": null
-              },
-              "distance": 5043.52,
-              "headsign": "Forest Hills via South Bay Center",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:18:15-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:25:48-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "duration": 453.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 34.79,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Franklin Park Road"
-                },
-                {
-                  "distance": 13.01,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 51.01,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "trip": null,
-              "distance": 520.79,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "accessibility_score": null
-        }
-      ],
-      "routing_errors": [],
-      "search_window_used": 7200
-    },
-    "ideal_plan": {
-      "date": "2025-07-16T12:14:00.000-04:00",
-      "itineraries": [
-        {
-          "start": "2025-07-16T12:18:11-04:00",
-          "end": "2025-07-16T13:25:33-04:00",
-          "duration": 4042,
-          "generalized_cost": 7392,
-          "walk_distance": 715.0699999999999,
-          "number_of_transfers": 1,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:20:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-07-16T12:45:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1.5e3,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                },
-                {
-                  "name": "Downtown Crossing"
-                },
-                {
-                  "name": "South Station"
-                },
-                {
-                  "name": "Broadway"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349515",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 13074.0,
-              "headsign": "Braintree",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:45:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T12:45:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "duration": 49.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 20.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 23.89,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "mrjaGjmupL??\\h@Fo@"
-              },
-              "trip": null,
-              "distance": 56.2,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:51:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-07-16T13:18:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us-initial:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "duration": 1620.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "sort_order": 50160,
-                "gtfs_id": "mbta-ma-us-initial:16",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "16",
-                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "South Bay Mall @ Target"
-                },
-                {
-                  "name": "South Bay Mall opp Macy's"
-                },
-                {
-                  "name": "South Bay Mall @ Allstate Rd"
-                },
-                {
-                  "name": "Massachusetts Ave opp Clapp St"
-                },
-                {
-                  "name": "Massachusetts Ave @ Columbia Rd"
-                },
-                {
-                  "name": "Columbia Rd @ Holden St"
-                },
-                {
-                  "name": "Columbia Rd @ Dudley St"
-                },
-                {
-                  "name": "Columbia Rd @ Bird St"
-                },
-                {
-                  "name": "Columbia Rd @ Glendale St"
-                },
-                {
-                  "name": "Columbia Rd @ Quincy St"
-                },
-                {
-                  "name": "Columbia Rd @ Hamilton St"
-                },
-                {
-                  "name": "Columbia Rd opp Wyola Pl"
-                },
-                {
-                  "name": "Columbia Rd @ Devon St"
-                },
-                {
-                  "name": "Columbia Rd @ Geneva Ave"
-                },
-                {
-                  "name": "Columbia Rd @ Washington St"
-                },
-                {
-                  "name": "Columbia Rd @ Seaver St"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "arjaGdmupL?cCd@An@?`@Jm@tFm@jECR[hDWnBQ~ASbBAFg@lEET?VJRHPb@FNCHIHEDKBQ?iAA[?????Y@e@Dg@FSFOLQb@c@bB}ATQPGLAP?RBVFTHhFbCz@b@????tCzAXP\\RFD??FD^t@FPBPCXGn@T?NDRPh@nAHn@j@tAt@tBJIj@_@hByAn@g@r@o@JI??jAeAfEgD|BgBrAeA????~@s@X[NUD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69703644",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills via South Bay Center",
-                "trip_short_name": null
-              },
-              "distance": 5043.52,
-              "headsign": "Forest Hills via South Bay Center",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:18:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:25:33-04:00",
+                "scheduled_time": "2025-08-05T16:22:12-04:00",
                 "estimated": null
               },
               "to": {
@@ -2840,11 +3375,11 @@
                 "lat": 42.303124,
                 "lon": -71.08595
               },
-              "duration": 453.0,
-              "realtime_state": null,
+              "duration": 432.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -2888,24 +3423,24 @@
               "real_time": false
             }
           ],
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-07-16T12:23:11-04:00",
-          "end": "2025-07-16T13:27:32-04:00",
-          "duration": 3861,
-          "generalized_cost": 8484,
-          "walk_distance": 947.36,
+          "generalized_cost": 8122,
+          "duration": 4141,
           "number_of_transfers": 2,
+          "walk_distance": 715.0699999999999
+        },
+        {
+          "start": "2025-08-05T15:23:11-04:00",
+          "end": "2025-08-05T16:25:04-04:00",
+          "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:25:00-04:00",
+                "scheduled_time": "2025-08-05T15:25:00-04:00",
                 "estimated": null
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:44:00-04:00",
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
                 "estimated": null
               },
               "to": {
@@ -2941,25 +3476,25 @@
                 "lon": -71.140698
               },
               "duration": 1140.0,
-              "realtime_state": null,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
-                "sort_order": 10010,
                 "gtfs_id": "mbta-ma-us-initial:Red",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Red Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10010
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Davis"
@@ -2989,7 +3524,7 @@
                 "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349296",
+                "gtfs_id": "mbta-ma-us-initial:69349313",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
@@ -3000,12 +3535,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:44:00-04:00",
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:45:47-04:00",
+                "scheduled_time": "2025-08-05T15:45:49-04:00",
                 "estimated": null
               },
               "to": {
@@ -3040,11 +3575,11 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 107.0,
-              "realtime_state": null,
+              "duration": 109.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -3083,12 +3618,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:49:00-04:00",
+                "scheduled_time": "2025-08-05T15:49:00-04:00",
                 "estimated": null
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T13:01:00-04:00",
+                "scheduled_time": "2025-08-05T16:02:00-04:00",
                 "estimated": null
               },
               "to": {
@@ -3123,26 +3658,26 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 720.0,
-              "realtime_state": null,
+              "duration": 780.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "ED8B00",
-                "sort_order": 10020,
                 "gtfs_id": "mbta-ma-us-initial:Orange",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Orange Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10020
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Chinatown"
@@ -3169,7 +3704,7 @@
                 "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575103",
+                "gtfs_id": "mbta-ma-us-initial:69575163",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills",
                 "trip_short_name": null
@@ -3180,12 +3715,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:01:00-04:00",
+                "scheduled_time": "2025-08-05T16:02:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:02:01-04:00",
+                "scheduled_time": "2025-08-05T16:03:04-04:00",
                 "estimated": null
               },
               "to": {
@@ -3220,11 +3755,11 @@
                 "lat": 42.323132,
                 "lon": -71.099592
               },
-              "duration": 61.0,
-              "realtime_state": null,
+              "duration": 64.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -3269,12 +3804,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:11:00-04:00",
+                "scheduled_time": "2025-08-05T16:07:00-04:00",
                 "estimated": null
               },
               "mode": "BUS",
               "end": {
-                "scheduled_time": "2025-07-16T13:19:00-04:00",
+                "scheduled_time": "2025-08-05T16:17:00-04:00",
                 "estimated": null
               },
               "to": {
@@ -3307,26 +3842,26 @@
                 "lat": 42.323074,
                 "lon": -71.099546
               },
-              "duration": 480.0,
-              "realtime_state": null,
+              "duration": 600.0,
               "transit_leg": true,
               "route": {
                 "type": 3,
                 "mode": "BUS",
                 "desc": "Frequent Bus",
                 "color": "FFC72C",
-                "sort_order": 50220,
                 "gtfs_id": "mbta-ma-us-initial:22",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": "22",
                 "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
+                "text_color": "000000",
+                "sort_order": 50220
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Columbus Ave @ Dimock St"
@@ -3353,7 +3888,7 @@
                 "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69703873",
+                "gtfs_id": "mbta-ma-us-initial:69699370",
                 "direction_id": "0",
                 "trip_headsign": "Ashmont",
                 "trip_short_name": null
@@ -3364,12 +3899,12 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:19:00-04:00",
+                "scheduled_time": "2025-08-05T16:17:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:27:32-04:00",
+                "scheduled_time": "2025-08-05T16:25:04-04:00",
                 "estimated": null
               },
               "to": {
@@ -3392,11 +3927,11 @@
                 "lat": 42.307515,
                 "lon": -71.089263
               },
-              "duration": 512.0,
-              "realtime_state": null,
+              "duration": 484.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -3452,423 +3987,24 @@
               "real_time": false
             }
           ],
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-07-16T12:28:11-04:00",
-          "end": "2025-07-16T13:40:33-04:00",
-          "duration": 4342,
-          "generalized_cost": 7692,
-          "walk_distance": 715.0699999999999,
-          "number_of_transfers": 1,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:30:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-07-16T12:55:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1.5e3,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                },
-                {
-                  "name": "Downtown Crossing"
-                },
-                {
-                  "name": "South Station"
-                },
-                {
-                  "name": "Broadway"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349516",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 13074.0,
-              "headsign": "Braintree",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:55:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T12:55:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "duration": 49.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 20.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 23.89,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "mrjaGjmupL??\\h@Fo@"
-              },
-              "trip": null,
-              "distance": 56.2,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:06:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-07-16T13:33:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us-initial:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "duration": 1620.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "sort_order": 50160,
-                "gtfs_id": "mbta-ma-us-initial:16",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "16",
-                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "South Bay Mall @ Target"
-                },
-                {
-                  "name": "South Bay Mall opp Macy's"
-                },
-                {
-                  "name": "South Bay Mall @ Allstate Rd"
-                },
-                {
-                  "name": "Massachusetts Ave opp Clapp St"
-                },
-                {
-                  "name": "Massachusetts Ave @ Columbia Rd"
-                },
-                {
-                  "name": "Columbia Rd @ Holden St"
-                },
-                {
-                  "name": "Columbia Rd @ Dudley St"
-                },
-                {
-                  "name": "Columbia Rd @ Bird St"
-                },
-                {
-                  "name": "Columbia Rd @ Glendale St"
-                },
-                {
-                  "name": "Columbia Rd @ Quincy St"
-                },
-                {
-                  "name": "Columbia Rd @ Hamilton St"
-                },
-                {
-                  "name": "Columbia Rd opp Wyola Pl"
-                },
-                {
-                  "name": "Columbia Rd @ Devon St"
-                },
-                {
-                  "name": "Columbia Rd @ Geneva Ave"
-                },
-                {
-                  "name": "Columbia Rd @ Washington St"
-                },
-                {
-                  "name": "Columbia Rd @ Seaver St"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "arjaGdmupL?cCd@An@?`@Jm@tFm@jECR[hDWnBQ~ASbBAFg@lEET?VJRHPb@FNCHIHEDKBQ?iAA[?????Y@e@Dg@FSFOLQb@c@bB}ATQPGLAP?RBVFTHhFbCz@b@????tCzAXP\\RFD??FD^t@FPBPCXGn@T?NDRPh@nAHn@j@tAt@tBJIj@_@hByAn@g@r@o@JI??jAeAfEgD|BgBrAeA????~@s@X[NUD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69702406",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills via South Bay Center",
-                "trip_short_name": null
-              },
-              "distance": 5043.52,
-              "headsign": "Forest Hills via South Bay Center",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:33:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:40:33-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
-                  "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us-initial:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "duration": 453.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 34.79,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Franklin Park Road"
-                },
-                {
-                  "distance": 13.01,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 51.01,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "trip": null,
-              "distance": 520.79,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-07-16T12:34:11-04:00",
-          "end": "2025-07-16T13:42:32-04:00",
-          "duration": 4101,
-          "generalized_cost": 8724,
-          "walk_distance": 947.36,
+          "generalized_cost": 8385,
+          "duration": 3713,
           "number_of_transfers": 2,
+          "walk_distance": 947.36
+        },
+        {
+          "start": "2025-08-05T15:18:11-04:00",
+          "end": "2025-08-05T16:25:14-04:00",
+          "accessibility_score": null,
           "legs": [
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:36:00-04:00",
+                "scheduled_time": "2025-08-05T15:20:00-04:00",
                 "estimated": null
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T12:55:00-04:00",
+                "scheduled_time": "2025-08-05T15:39:00-04:00",
                 "estimated": null
               },
               "to": {
@@ -3904,25 +4040,25 @@
                 "lon": -71.140698
               },
               "duration": 1140.0,
-              "realtime_state": null,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "DA291C",
-                "sort_order": 10010,
                 "gtfs_id": "mbta-ma-us-initial:Red",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Red Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10010
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Davis"
@@ -3952,23 +4088,23 @@
                 "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349297",
+                "gtfs_id": "mbta-ma-us-initial:69349532",
                 "direction_id": "0",
-                "trip_headsign": "Ashmont",
+                "trip_headsign": "Braintree",
                 "trip_short_name": null
               },
               "distance": 9820.78,
-              "headsign": "Ashmont",
+              "headsign": "Braintree",
               "real_time": false
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T12:55:00-04:00",
+                "scheduled_time": "2025-08-05T15:39:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T12:56:47-04:00",
+                "scheduled_time": "2025-08-05T15:40:49-04:00",
                 "estimated": null
               },
               "to": {
@@ -4003,11 +4139,11 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 107.0,
-              "realtime_state": null,
+              "duration": 109.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
@@ -4046,29 +4182,29 @@
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:03:00-04:00",
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
                 "estimated": null
               },
               "mode": "SUBWAY",
               "end": {
-                "scheduled_time": "2025-07-16T13:15:00-04:00",
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
                 "estimated": null
               },
               "to": {
-                "name": "Jackson Square",
+                "name": "Green Street",
                 "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
+                  "name": "Green Street",
+                  "url": "https://www.mbta.com/stops/place-grnst",
+                  "gtfs_id": "mbta-ma-us-initial:70002",
                   "vehicle_mode": "SUBWAY",
                   "wheelchair_boarding": "POSSIBLE",
                   "zone_id": "RapidTransit",
                   "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
                   }
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
+                "lat": 42.309832,
+                "lon": -71.108059
               },
               "from": {
                 "name": "Downtown Crossing",
@@ -4086,26 +4222,26 @@
                 "lat": 42.355518,
                 "lon": -71.060225
               },
-              "duration": 720.0,
-              "realtime_state": null,
+              "duration": 960.0,
               "transit_leg": true,
               "route": {
                 "type": 1,
                 "mode": "SUBWAY",
                 "desc": "Rapid Transit",
                 "color": "ED8B00",
-                "sort_order": 10020,
                 "gtfs_id": "mbta-ma-us-initial:Orange",
                 "agency": {
                   "name": "MBTA"
                 },
                 "short_name": null,
                 "long_name": "Orange Line",
-                "text_color": "FFFFFF"
+                "text_color": "FFFFFF",
+                "sort_order": 10020
               },
               "agency": {
                 "name": "MBTA"
               },
+              "realtime_state": "SCHEDULED",
               "intermediate_stops": [
                 {
                   "name": "Chinatown"
@@ -4124,215 +4260,37 @@
                 },
                 {
                   "name": "Roxbury Crossing"
+                },
+                {
+                  "name": "Jackson Square"
+                },
+                {
+                  "name": "Stony Brook"
                 }
               ],
               "steps": [],
               "leg_geometry": {
                 "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
+                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
               },
               "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575115",
+                "gtfs_id": "mbta-ma-us-initial:69575153",
                 "direction_id": "0",
                 "trip_headsign": "Forest Hills",
                 "trip_short_name": null
               },
-              "distance": 5215.25,
+              "distance": 6857.3,
               "headsign": "Forest Hills",
               "real_time": false
             },
             {
               "start": {
-                "scheduled_time": "2025-07-16T13:15:00-04:00",
+                "scheduled_time": "2025-08-05T16:00:00-04:00",
                 "estimated": null
               },
               "mode": "WALK",
               "end": {
-                "scheduled_time": "2025-07-16T13:16:01-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "duration": 61.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
-              },
-              "trip": null,
-              "distance": 71.02,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:26:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-07-16T13:34:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us-initial:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "duration": 480.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Frequent Bus",
-                "color": "FFC72C",
-                "sort_order": 50220,
-                "gtfs_id": "mbta-ma-us-initial:22",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "22",
-                "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Columbus Ave @ Dimock St"
-                },
-                {
-                  "name": "Columbus Ave opp Bray St"
-                },
-                {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
-                },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
-                },
-                {
-                  "name": "Seaver St opp Harold St"
-                },
-                {
-                  "name": "Seaver St opp Humboldt Ave"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69703874",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 2101.86,
-              "headsign": "Ashmont",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:34:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:42:32-04:00",
+                "scheduled_time": "2025-08-05T16:25:14-04:00",
                 "estimated": null
               },
               "to": {
@@ -4342,621 +4300,98 @@
                 "lon": -71.090434
               },
               "from": {
-                "name": "Seaver St opp Elm Hill Ave",
+                "name": "Green Street",
                 "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us-initial:17401",
-                  "vehicle_mode": "BUS",
+                  "name": "Green Street",
+                  "url": "https://www.mbta.com/stops/place-grnst",
+                  "gtfs_id": "mbta-ma-us-initial:70002",
+                  "vehicle_mode": "SUBWAY",
                   "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
+                  }
                 },
-                "lat": 42.307515,
-                "lon": -71.089263
+                "lat": 42.309832,
+                "lon": -71.108059
               },
-              "duration": 512.0,
-              "realtime_state": null,
+              "duration": 1514.0,
               "transit_leg": false,
               "route": null,
               "agency": null,
+              "realtime_state": null,
               "intermediate_stops": [],
               "steps": [
                 {
-                  "distance": 244.74,
-                  "absolute_direction": "WEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "trip": null,
-              "distance": 608.11,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-07-16T12:39:11-04:00",
-          "end": "2025-07-16T13:46:29-04:00",
-          "duration": 4038,
-          "generalized_cost": 9070,
-          "walk_distance": 1087.19,
-          "number_of_transfers": 2,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T12:41:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-07-16T13:00:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1140.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349517",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Braintree",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:00:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:01:47-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 107.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:10:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-07-16T13:22:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 720.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us-initial:Orange",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
-                },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575121",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 5215.25,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:22:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:23:01-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "duration": 61.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
+                  "distance": 67.67,
+                  "absolute_direction": "NORTHEAST",
                   "relative_direction": "FOLLOW_SIGNS",
                   "street_name": "Exit to street"
                 },
                 {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
+                  "distance": 19.37,
+                  "absolute_direction": "NORTHEAST",
                   "relative_direction": "CONTINUE",
                   "street_name": "pathway"
                 },
                 {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
+                  "distance": 11.89,
+                  "absolute_direction": "NORTHEAST",
                   "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
+                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
                 },
                 {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
-              },
-              "trip": null,
-              "distance": 71.02,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:30:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-07-16T13:35:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Humboldt Ave @ Seaver St",
-                "stop": {
-                  "name": "Humboldt Ave @ Seaver St",
-                  "url": "https://www.mbta.com/stops/1325",
-                  "gtfs_id": "mbta-ma-us-initial:1325",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.31045,
-                "lon": -71.091588
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "duration": 300.0,
-              "realtime_state": null,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "sort_order": 50440,
-                "gtfs_id": "mbta-ma-us-initial:44",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "44",
-                "long_name": "Jackson Square Station - Ruggles Station",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "intermediate_stops": [
-                {
-                  "name": "Columbus Ave @ Dimock St"
+                  "distance": 0.0,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "EXIT_STATION",
+                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
                 },
                 {
-                  "name": "Columbus Ave opp Bray St"
-                },
-                {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
-                },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
-                },
-                {
-                  "name": "Seaver St opp Harold St"
-                }
-              ],
-              "steps": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBQS}@s@k@e@"
-              },
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69703520",
-                "direction_id": "1",
-                "trip_headsign": "Ruggles",
-                "trip_short_name": null
-              },
-              "distance": 1832.48,
-              "headsign": "Ruggles",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-07-16T13:35:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-07-16T13:46:29-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Humboldt Ave @ Seaver St",
-                "stop": {
-                  "name": "Humboldt Ave @ Seaver St",
-                  "url": "https://www.mbta.com/stops/1325",
-                  "gtfs_id": "mbta-ma-us-initial:1325",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.31045,
-                "lon": -71.091588
-              },
-              "duration": 689.0,
-              "realtime_state": null,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "intermediate_stops": [],
-              "steps": [
-                {
-                  "distance": 56.06,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Humboldt Avenue"
-                },
-                {
-                  "distance": 17.46,
+                  "distance": 170.33,
                   "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 22.54,
-                  "absolute_direction": "SOUTHWEST",
                   "relative_direction": "RIGHT",
-                  "street_name": "path"
+                  "street_name": "sidewalk"
                 },
                 {
-                  "distance": 50.64,
-                  "absolute_direction": "SOUTHEAST",
+                  "distance": 5.09,
+                  "absolute_direction": "NORTHEAST",
                   "relative_direction": "LEFT",
+                  "street_name": "Union Avenue"
+                },
+                {
+                  "distance": 102.98,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "Green Street"
+                },
+                {
+                  "distance": 420.06,
+                  "absolute_direction": "EAST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "Glen Road"
+                },
+                {
+                  "distance": 318.77,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "SLIGHTLY_RIGHT",
+                  "street_name": "Glen Lane"
+                },
+                {
+                  "distance": 155.39,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
                   "street_name": "bike path"
                 },
                 {
-                  "distance": 237.9,
-                  "absolute_direction": "SOUTHEAST",
+                  "distance": 294.71,
+                  "absolute_direction": "NORTHEAST",
                   "relative_direction": "LEFT",
-                  "street_name": "service road"
+                  "street_name": "Pierpont Road"
                 },
                 {
                   "distance": 42.5,
                   "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
+                  "relative_direction": "RIGHT",
                   "street_name": "path"
                 },
                 {
@@ -4992,19 +4427,469 @@
               ],
               "leg_geometry": {
                 "length": null,
-                "points": "iwfaGla|pLCJb@\\b@\\FFDBFKHAFC@BHJFLFHFCBEZc@JNDBD@F?@E@GBER]r@u@NQTQp@S\\GTBTHPHRN^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
+                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
               },
               "trip": null,
-              "distance": 747.94,
+              "distance": 1929.63,
               "headsign": null,
               "real_time": false
             }
           ],
-          "accessibility_score": null
+          "generalized_cost": 11820,
+          "duration": 4023,
+          "number_of_transfers": 1,
+          "walk_distance": 2197.86
+        },
+        {
+          "start": "2025-08-05T15:23:11-04:00",
+          "end": "2025-08-05T16:30:14-04:00",
+          "accessibility_score": null,
+          "legs": [
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:25:00-04:00",
+                "estimated": null
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us-initial:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "from": {
+                "name": "Alewife",
+                "stop": {
+                  "name": "Alewife",
+                  "url": "https://www.mbta.com/stops/place-alfcl",
+                  "gtfs_id": "mbta-ma-us-initial:70061",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                  }
+                },
+                "lat": 42.396148,
+                "lon": -71.140698
+              },
+              "duration": 1140.0,
+              "transit_leg": true,
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "DA291C",
+                "gtfs_id": "mbta-ma-us-initial:Red",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Red Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10010
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "SCHEDULED",
+              "intermediate_stops": [
+                {
+                  "name": "Davis"
+                },
+                {
+                  "name": "Porter"
+                },
+                {
+                  "name": "Harvard"
+                },
+                {
+                  "name": "Central"
+                },
+                {
+                  "name": "Kendall/MIT"
+                },
+                {
+                  "name": "Charles/MGH"
+                },
+                {
+                  "name": "Park Street"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us-initial:69349313",
+                "direction_id": "0",
+                "trip_headsign": "Ashmont",
+                "trip_short_name": null
+              },
+              "distance": 9820.78,
+              "headsign": "Ashmont",
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:44:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T15:45:49-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us-initial:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "from": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us-initial:70077",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "duration": 109.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 36.12,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Concourse | CharlieCard Store"
+                },
+                {
+                  "distance": 77.57,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                },
+                {
+                  "distance": 16.46,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Orange Line - Forest Hills"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "}poaGl}upL????????"
+              },
+              "trip": null,
+              "distance": 130.15,
+              "headsign": null,
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T15:49:00-04:00",
+                "estimated": null
+              },
+              "mode": "SUBWAY",
+              "end": {
+                "scheduled_time": "2025-08-05T16:05:00-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Green Street",
+                "stop": {
+                  "name": "Green Street",
+                  "url": "https://www.mbta.com/stops/place-grnst",
+                  "gtfs_id": "mbta-ma-us-initial:70002",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
+                  }
+                },
+                "lat": 42.309832,
+                "lon": -71.108059
+              },
+              "from": {
+                "name": "Downtown Crossing",
+                "stop": {
+                  "name": "Downtown Crossing",
+                  "url": "https://www.mbta.com/stops/place-dwnxg",
+                  "gtfs_id": "mbta-ma-us-initial:70020",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                  }
+                },
+                "lat": 42.355518,
+                "lon": -71.060225
+              },
+              "duration": 960.0,
+              "transit_leg": true,
+              "route": {
+                "type": 1,
+                "mode": "SUBWAY",
+                "desc": "Rapid Transit",
+                "color": "ED8B00",
+                "gtfs_id": "mbta-ma-us-initial:Orange",
+                "agency": {
+                  "name": "MBTA"
+                },
+                "short_name": null,
+                "long_name": "Orange Line",
+                "text_color": "FFFFFF",
+                "sort_order": 10020
+              },
+              "agency": {
+                "name": "MBTA"
+              },
+              "realtime_state": "SCHEDULED",
+              "intermediate_stops": [
+                {
+                  "name": "Chinatown"
+                },
+                {
+                  "name": "Tufts Medical Center"
+                },
+                {
+                  "name": "Back Bay"
+                },
+                {
+                  "name": "Massachusetts Avenue"
+                },
+                {
+                  "name": "Ruggles"
+                },
+                {
+                  "name": "Roxbury Crossing"
+                },
+                {
+                  "name": "Jackson Square"
+                },
+                {
+                  "name": "Stony Brook"
+                }
+              ],
+              "steps": [],
+              "leg_geometry": {
+                "length": null,
+                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
+              },
+              "trip": {
+                "gtfs_id": "mbta-ma-us-initial:69575163",
+                "direction_id": "0",
+                "trip_headsign": "Forest Hills",
+                "trip_short_name": null
+              },
+              "distance": 6857.3,
+              "headsign": "Forest Hills",
+              "real_time": false
+            },
+            {
+              "start": {
+                "scheduled_time": "2025-08-05T16:05:00-04:00",
+                "estimated": null
+              },
+              "mode": "WALK",
+              "end": {
+                "scheduled_time": "2025-08-05T16:30:14-04:00",
+                "estimated": null
+              },
+              "to": {
+                "name": "Franklin Park Zoo",
+                "stop": null,
+                "lat": 42.305067,
+                "lon": -71.090434
+              },
+              "from": {
+                "name": "Green Street",
+                "stop": {
+                  "name": "Green Street",
+                  "url": "https://www.mbta.com/stops/place-grnst",
+                  "gtfs_id": "mbta-ma-us-initial:70002",
+                  "vehicle_mode": "SUBWAY",
+                  "wheelchair_boarding": "POSSIBLE",
+                  "zone_id": "RapidTransit",
+                  "parent_station": {
+                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
+                  }
+                },
+                "lat": 42.309832,
+                "lon": -71.108059
+              },
+              "duration": 1514.0,
+              "transit_leg": false,
+              "route": null,
+              "agency": null,
+              "realtime_state": null,
+              "intermediate_stops": [],
+              "steps": [
+                {
+                  "distance": 67.67,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Exit to street"
+                },
+                {
+                  "distance": 19.37,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "pathway"
+                },
+                {
+                  "distance": 11.89,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "FOLLOW_SIGNS",
+                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
+                },
+                {
+                  "distance": 0.0,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "EXIT_STATION",
+                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
+                },
+                {
+                  "distance": 170.33,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "sidewalk"
+                },
+                {
+                  "distance": 5.09,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Union Avenue"
+                },
+                {
+                  "distance": 102.98,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "Green Street"
+                },
+                {
+                  "distance": 420.06,
+                  "absolute_direction": "EAST",
+                  "relative_direction": "CONTINUE",
+                  "street_name": "Glen Road"
+                },
+                {
+                  "distance": 318.77,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "SLIGHTLY_RIGHT",
+                  "street_name": "Glen Lane"
+                },
+                {
+                  "distance": 155.39,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "bike path"
+                },
+                {
+                  "distance": 294.71,
+                  "absolute_direction": "NORTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "Pierpont Road"
+                },
+                {
+                  "distance": 42.5,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "path"
+                },
+                {
+                  "distance": 57.09,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "SLIGHTLY_LEFT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 89.98,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "RIGHT",
+                  "street_name": "service road"
+                },
+                {
+                  "distance": 12.65,
+                  "absolute_direction": "SOUTHWEST",
+                  "relative_direction": "RIGHT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 156.98,
+                  "absolute_direction": "SOUTHEAST",
+                  "relative_direction": "LEFT",
+                  "street_name": "open area"
+                },
+                {
+                  "distance": 4.18,
+                  "absolute_direction": "SOUTH",
+                  "relative_direction": "LEFT",
+                  "street_name": "path"
+                }
+              ],
+              "leg_geometry": {
+                "length": null,
+                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
+              },
+              "trip": null,
+              "distance": 1929.63,
+              "headsign": null,
+              "real_time": false
+            }
+          ],
+          "generalized_cost": 11820,
+          "duration": 4023,
+          "number_of_transfers": 1,
+          "walk_distance": 2197.86
         }
       ],
-      "routing_errors": [],
-      "search_window_used": 7200
+      "search_date_time": "2025-08-05T15:11:24-04:00"
     }
   }
 }

--- a/test/open_trip_planner_client/error_test.exs
+++ b/test/open_trip_planner_client/error_test.exs
@@ -61,17 +61,11 @@ defmodule OpenTripPlannerClient.ErrorTest do
     end
 
     test "detailed message for NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW" do
-      search_window_used = Faker.random_between(600, 7200)
-      date = Faker.DateTime.forward(2)
-
       plan =
         build(:plan, %{
-          date: Timex.to_unix(date) * 1000,
-          itineraries: [],
           routing_errors: [
             build(:routing_error, %{code: "NO_TRANSIT_CONNECTION_IN_SEARCH_WINDOW"})
-          ],
-          search_window_used: search_window_used
+          ]
         })
 
       assert [%Error{message: message}] = from_routing_errors(plan)

--- a/test/open_trip_planner_client/plan_params_test.exs
+++ b/test/open_trip_planner_client/plan_params_test.exs
@@ -80,7 +80,7 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
         Faker.random_between(1, 5)
         |> Faker.Util.sample_uniq(fn -> Faker.Util.pick(@non_subway_modes) end)
 
-      assert %PlanParams{transportModes: %{transit: %{transit: modes_param}}} =
+      assert %PlanParams{modes: %{transit: %{transit: modes_param}}} =
                PlanParams.new(from, to, modes: modes)
 
       assert Enum.map(modes_param, &Map.get(&1, :mode)) == modes
@@ -93,14 +93,14 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
           |> Faker.Util.sample_uniq(fn -> Faker.Util.pick(@non_subway_modes) end)
       ]
 
-      assert %PlanParams{transportModes: %{transit: %{transit: modes_param}}} =
+      assert %PlanParams{modes: %{transit: %{transit: modes_param}}} =
                PlanParams.new(from, to, modes: modes)
 
       assert Enum.map(modes_param, &Map.get(&1, :mode)) == [:TRAM | modes]
     end
 
     test "handles no transit modes", %{from: from, to: to} do
-      assert %PlanParams{transportModes: %{}} =
+      assert %PlanParams{modes: %{directOnly: true}} =
                PlanParams.new(from, to, modes: [])
     end
   end

--- a/test/open_trip_planner_client/plan_params_test.exs
+++ b/test/open_trip_planner_client/plan_params_test.exs
@@ -80,7 +80,9 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
         Faker.random_between(1, 5)
         |> Faker.Util.sample_uniq(fn -> Faker.Util.pick(@non_subway_modes) end)
 
-      assert %PlanParams{transportModes: modes_param} = PlanParams.new(from, to, modes: modes)
+      assert %PlanParams{transportModes: %{transit: %{transit: modes_param}}} =
+               PlanParams.new(from, to, modes: modes)
+
       assert Enum.map(modes_param, &Map.get(&1, :mode)) == modes
     end
 
@@ -91,8 +93,15 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
           |> Faker.Util.sample_uniq(fn -> Faker.Util.pick(@non_subway_modes) end)
       ]
 
-      assert %PlanParams{transportModes: modes_param} = PlanParams.new(from, to, modes: modes)
+      assert %PlanParams{transportModes: %{transit: %{transit: modes_param}}} =
+               PlanParams.new(from, to, modes: modes)
+
       assert Enum.map(modes_param, &Map.get(&1, :mode)) == [:TRAM | modes]
+    end
+
+    test "handles no transit modes", %{from: from, to: to} do
+      assert %PlanParams{transportModes: %{}} =
+               PlanParams.new(from, to, modes: [])
     end
   end
 end

--- a/test/open_trip_planner_client/plan_test.exs
+++ b/test/open_trip_planner_client/plan_test.exs
@@ -4,16 +4,15 @@ defmodule OpenTripPlannerClient.PlanTest do
 
   test "creates structs from maps" do
     map = %{
-      itineraries: [],
-      searchWindowUsed: Faker.random_between(30, 30_000)
+      itineraries: []
     }
 
     assert {:ok, %Plan{}} = Nestru.decode(map, Plan)
   end
 
   test "updates unix timestamps to DateTime in local timezone" do
-    map = %{date: (Faker.DateTime.forward(1) |> Timex.to_unix()) * 1000}
-    assert {:ok, %Plan{date: parsed_date}} = Nestru.decode(map, Plan)
+    map = %{search_date_time: Faker.DateTime.forward(1) |> DateTime.to_iso8601()}
+    assert {:ok, %Plan{search_date_time: parsed_date}} = Nestru.decode(map, Plan)
     assert parsed_date.time_zone == Application.fetch_env!(:open_trip_planner_client, :timezone)
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -323,7 +323,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
         origin: build(:location_param),
         destination: build(:location_param),
         dateTime: build(:datetime_param),
-        transportModes: build(:modes_param),
+        modes: build(:modes_param),
         wheelchair: Faker.Util.pick([true, false])
       }
     end
@@ -336,7 +336,11 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
         end)
         |> Enum.map(&Map.new(mode: &1))
 
-      sequence(:modes, fn _ -> modes end)
+      %{
+        transit: %{
+          transit: modes
+        }
+      }
     end
 
     def datetime_param_factory(_) do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -28,10 +28,9 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
 
     def plan_factory do
       %Plan{
-        date: Faker.DateTime.forward(2),
         itineraries: __MODULE__.build_list(3, :itinerary),
         routing_errors: [],
-        search_window_used: 3600
+        search_date_time: Faker.DateTime.forward(2) |> DateTime.to_iso8601()
       }
     end
 
@@ -321,11 +320,9 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
 
     def plan_params_factory do
       %PlanParams{
-        fromPlace: build(:place_param),
-        toPlace: build(:place_param),
-        date: build(:date_param),
-        time: build(:time_param),
-        arriveBy: Faker.Util.pick([true, false]),
+        origin: build(:location_param),
+        destination: build(:location_param),
+        dateTime: build(:datetime_param),
         transportModes: build(:modes_param),
         wheelchair: Faker.Util.pick([true, false])
       }
@@ -342,45 +339,39 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
       sequence(:modes, fn _ -> modes end)
     end
 
-    def date_param_factory(_) do
-      formatted =
+    def datetime_param_factory(_) do
+      key = Faker.Util.pick([:earliestDeparture, :latestArrival])
+
+      date =
         Faker.DateTime.forward(2)
-        |> Timex.format!("{YYYY}-{0M}-{0D}")
+        |> DateTime.to_iso8601()
 
-      sequence(:date, fn _ -> formatted end)
+      Map.put(%{}, key, date)
     end
 
-    def time_param_factory(_) do
-      formatted =
-        Faker.DateTime.forward(2)
-        |> Timex.format!("{h12}:{m}{am}")
-
-      sequence(:time, fn _ -> formatted end)
-    end
-
-    def place_param_factory(_) do
-      [:lat_lon_place_param, :stop_place_param]
-      |> Faker.Util.pick()
-      |> build()
-    end
-
-    def lat_lon_place_param_factory(_) do
+    def location_param_factory(_) do
       lat = Faker.Address.latitude()
       lon = Faker.Address.longitude()
 
-      sequence(
-        :other_place,
-        fn _ -> "#{Faker.Address.street_name()}::#{lat},#{lon}" end
-      )
+      %{
+        label: Faker.Address.street_name(),
+        location: %{coordinate: %{latitude: lat, longitude: lon}}
+      }
     end
 
-    def stop_place_param_factory(_) do
-      sequence(
-        :stop_place,
-        fn _ ->
-          "#{Faker.Address.street_name()}::#{gtfs_prefix()}:#{Faker.Internet.slug()}"
-        end
-      )
+    def location_stop_param_factory(_) do
+      stop_id =
+        sequence(
+          :stop_place,
+          fn _ ->
+            "#{gtfs_prefix()}:#{Faker.Internet.slug()}"
+          end
+        )
+
+      %{
+        label: Faker.Address.street_name(),
+        location: %{stopLocation: stop_id}
+      }
     end
 
     def mbta_bus_leg_factory(attrs) do


### PR DESCRIPTION
> [!IMPORTANT]
> This is a breaking change for consumers specifying their own datetime or arriveBy value.

Related PR in otp-deploy for upgrading OpenTripPlanner
- https://github.com/mbta/otp-deploy/pull/46

As of v2.7, OpenTripPlanner's `plan` query [^1] is soft deprecated in favor in the newer `planConnection` query [^2]. The outputs of each are quite similar, through not identical [^3][^4]. However, the inputs are structured _very_ differently, so `plan.graphql` is substantially rewritten, and `%PlanParams{}` are heavily adjusted to work more smoothly with the expected arguments.

[^1]: https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/plan
[^2]: https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/planConnection
[^3]: https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/Plan
[^4]: https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/PlanConnection