### PR TITLE
feat(PlanParams): enable a custom locale

### DIFF
--- a/lib/open_trip_planner_client/plan_params.ex
+++ b/lib/open_trip_planner_client/plan_params.ex
@@ -11,6 +11,7 @@ defmodule OpenTripPlannerClient.PlanParams do
     :destination,
     :dateTime,
     :modes,
+    locale: "en",
     numItineraries: 5,
     wheelchair: false
   ]
@@ -86,16 +87,18 @@ defmodule OpenTripPlannerClient.PlanParams do
     `false`, depart at a certain time. Defalts to false.
   * `:datetime` - The DateTime to depart from the origin or arrive at the
     destination. Defaults to now.
+  * `:locale` - The locale to use for the plan, defaults to `"en"`.
   * `:modes` - The transit modes to be used in the plan. Defaults to all modes.
   * `:num_itineraries` - The maximum number of itineraries to return. Defaults
     to 5.
-  * `:wheelchair` - Whether to limit itineraries to those that are wheelchair 
+  * `:wheelchair` - Whether to limit itineraries to those that are wheelchair
     accessible. Defaults to false.
 
   """
   @type opts :: [
           arrive_by: boolean(),
           datetime: DateTime.t(),
+          locale: String.t(),
           modes: [mode_t()],
           num_itineraries: non_neg_integer(),
           wheelchair: boolean()
@@ -107,6 +110,7 @@ defmodule OpenTripPlannerClient.PlanParams do
   @type t :: %__MODULE__{
           origin: place_location_input(),
           dateTime: datetime_map(),
+          locale: String.t(),
           numItineraries: integer(),
           destination: place_location_input(),
           modes: map(),
@@ -117,19 +121,21 @@ defmodule OpenTripPlannerClient.PlanParams do
   def modes, do: @modes
 
   @doc """
-  Arguments to send to OpenTripPlanner's `plan` query. 
+  Arguments to send to OpenTripPlanner's `plan` query.
 
   Defaults to 5 itineraries departing at the current time via walking or any mode of transit.
   """
   @spec new(place_map(), place_map(), opts()) :: t()
   def new(origin, destination, opts \\ []) do
     datetime = Keyword.get(opts, :datetime, OpenTripPlannerClient.Util.local_now())
+    locale = Keyword.get(opts, :locale, "en")
     modes = Keyword.get(opts, :modes, @modes)
 
     %__MODULE__{
       origin: to_location_param(origin),
       destination: to_location_param(destination),
       dateTime: Keyword.get(opts, :arrive_by, false) |> to_datetime_param(datetime),
+      locale: locale,
       numItineraries: Keyword.get(opts, :num_itineraries, 5),
       modes: to_modes_param(modes),
       wheelchair: Keyword.get(opts, :wheelchair, false)

--- a/lib/open_trip_planner_client/request.ex
+++ b/lib/open_trip_planner_client/request.ex
@@ -33,6 +33,7 @@ defmodule OpenTripPlannerClient.Request do
   @spec plan_connection(PlanParams.t()) :: {:ok, Req.Response.t()} | {:error, Exception.t()}
   def plan_connection(%PlanParams{} = params) do
     new()
+    |> Req.Request.put_header("accept-language", params.locale)
     |> Req.post(graphql: {@plan_query, params})
   rescue
     error ->

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -30,7 +30,6 @@ query TripPlan(
     modes: $modes,
     searchWindow: "2h"
     first: $numItineraries
-    locale: "en"
   ) { ...PlanInfo }
 
   idealPlan: planConnection(
@@ -57,7 +56,6 @@ query TripPlan(
     modes: $modes,
     searchWindow: "2h"
     first: $numItineraries
-    locale: "en"
   ) { ...PlanInfo }
 }
 

--- a/test/open_trip_planner_client/plan_params_test.exs
+++ b/test/open_trip_planner_client/plan_params_test.exs
@@ -31,6 +31,7 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
     test "provides defaults", %{from: from, to: to} do
       assert %PlanParams{
                dateTime: datetime,
+               locale: "en",
                numItineraries: 5,
                wheelchair: false
              } =
@@ -64,6 +65,13 @@ defmodule OpenTripPlannerClient.PlanParamsTest do
       refute Map.has_key?(arrive_datetime, :earliestDeparture)
       refute Map.has_key?(depart_datetime, :latestArrival)
       assert {:ok, _, _} = DateTime.from_iso8601(depart_datetime.earliestDeparture)
+    end
+
+    test "sets custom locale", %{from: from, to: to} do
+      locale = Faker.Util.pick(["es", "fr", "it"])
+
+      assert %PlanParams{locale: ^locale} =
+               PlanParams.new(from, to, locale: locale)
     end
 
     test "sets custom wheelchair", %{from: from, to: to} do

--- a/test/open_trip_planner_client/request_test.exs
+++ b/test/open_trip_planner_client/request_test.exs
@@ -1,0 +1,35 @@
+defmodule OpenTripPlannerClient.RequestTest do
+  @moduledoc false
+  use ExUnit.Case, async: false
+
+  import OpenTripPlannerClient.Request
+  import OpenTripPlannerClient.Test.Support.Factory
+
+  setup do
+    bypass = Bypass.open()
+    host = "http://localhost:#{bypass.port}"
+    old_otp_url = Application.get_env(:open_trip_planner_client, :otp_url)
+
+    on_exit(fn ->
+      Application.put_env(:open_trip_planner_client, :otp_url, old_otp_url)
+    end)
+
+    Application.put_env(:open_trip_planner_client, :otp_url, host)
+
+    {:ok, %{bypass: bypass}}
+  end
+
+  describe "plan_connection/1" do
+    test "can apply accept-language request header", %{bypass: bypass} do
+      plan_params = build(:plan_params)
+
+      Bypass.expect_once(bypass, fn conn ->
+        assert Plug.Conn.get_req_header(conn, "accept-language") == [plan_params.locale]
+
+        Plug.Conn.send_resp(conn, :ok, "{}")
+      end)
+
+      _ = plan_connection(plan_params)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -349,6 +349,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
         origin: build(:location_param),
         destination: build(:location_param),
         dateTime: build(:datetime_param),
+        locale: Faker.Util.pick(~w(en es it fr cn jp ko de)),
         modes: build(:modes_param),
         wheelchair: Faker.Util.pick([true, false])
       }


### PR DESCRIPTION
Although [`planConnection` has a `locale` argument](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/queries/planConnection), OpenTripPlanner's documentation appears to discourage this in favor of using an `accept-language` request header. So that's what this PR does!

**Asana Ticket**: [use the ´accept-language´ header in the OTP request](https://app.asana.com/1/15492006741476/project/555089885850811/task/1210710269085147?focus=true)

No action needed to continue using the "en" locale.

I'm actually not super sure what happens to OTP's output with other locales (last I tried locally I didn't notice a difference), but now we can find out! ✨ 