### PR TITLE
cleanup: Remove `length` field from `Geometry` struct and factory

### DIFF
--- a/lib/open_trip_planner_client/schema/geometry.ex
+++ b/lib/open_trip_planner_client/schema/geometry.ex
@@ -14,11 +14,9 @@ defmodule OpenTripPlannerClient.Schema.Geometry do
   @derive Nestru.Decoder
   schema do
     @typedoc """
-    * length - The number of points in the string
     * points - List of coordinates of in a Google encoded polyline format (see
       https://developers.google.com/maps/documentation/utilities/polylinealgorithm)
     """
-    field(:length, non_neg_integer())
     field(:points, polyline())
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -85,8 +85,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
 
     def geometry_factory do
       %Geometry{
-        points: Faker.String.base64(64),
-        length: nil
+        points: Faker.String.base64(64)
       }
     end
 


### PR DESCRIPTION
We aren't retrieving the `length` field in the [GraphQL query](https://github.com/mbta/open_trip_planner_client/blob/0d7ba8c51a23f7967c33044882fd455954160be6/priv/plan.graphql#L87), so defining it at all is a bit confusing.