### PR TITLE
cleanup: Remove trailing whitespace

### DIFF
--- a/lib/open_trip_planner_client/request.ex
+++ b/lib/open_trip_planner_client/request.ex
@@ -12,7 +12,7 @@ defmodule OpenTripPlannerClient.Request do
   # - Keeps automatic response body decoding, but transforms OTP's camel-case
   #   keys into snake-case
   # - Raises on HTTP 4XX/5XX responses instead of returning an :ok tuple
-  # - Configures the AbsintheClient plugin for making GraphQL requests  
+  # - Configures the AbsintheClient plugin for making GraphQL requests
   @spec new :: Req.Request.t()
   defp new do
     Req.new(


### PR DESCRIPTION
TIL that we **used to** be able to merge over [failing credo checks](https://github.com/mbta/open_trip_planner_client/actions/runs/21381264334).

This fixes the credo check that I should have fixed before merging 🥴 