### PR TITLE
chore: Add `gtfs_id` to `IntermediateStop` schema

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,7 @@ runs:
     id: asdf-cache
   
   - name: Install languages from .tool-versions (if needed)
-    uses: asdf-vm/actions/install@v1
+    uses: asdf-vm/actions/install@v4
     if: ${{ steps.asdf-cache.outputs.cache-hit != 'true' }}
  
   - name: Install Hex/Rebar (if needed)

--- a/lib/open_trip_planner_client/interlined_legs.ex
+++ b/lib/open_trip_planner_client/interlined_legs.ex
@@ -30,7 +30,12 @@ defmodule OpenTripPlannerClient.InterlinedLegs do
         distance: leg_1.distance + leg_2.distance,
         intermediate_stops:
           leg_1.intermediate_stops ++
-            [%IntermediateStop{name: leg_1.to.name}] ++
+            [
+              %IntermediateStop{
+                gtfs_id: leg_1.to.stop && leg_1.to.stop.gtfs_id,
+                name: leg_1.to.name
+              }
+            ] ++
             leg_2.intermediate_stops,
         leg_geometry: combine_geometries(leg_1.leg_geometry, leg_2.leg_geometry)
     }

--- a/lib/open_trip_planner_client/schema/stop.ex
+++ b/lib/open_trip_planner_client/schema/stop.ex
@@ -83,6 +83,7 @@ defmodule OpenTripPlannerClient.Schema.IntermediateStop do
 
   @derive Nestru.Decoder
   schema do
+    field(:gtfs_id, gtfs_id(), @nonnull_field)
     field(:name, String.t())
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -313,7 +313,10 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
     end
 
     def intermediate_stop_factory do
+      prefix = gtfs_prefix()
+
       %IntermediateStop{
+        gtfs_id: prefix <> Faker.Internet.slug(),
         name: Faker.Address.city()
       }
     end


### PR DESCRIPTION
**Asana Ticket:** [⛴️ 💸  Update OTP Client to return GTFS ID's for intermediate stops](https://app.asana.com/1/15492006741476/project/385363666817452/task/1216667427291931?focus=true)

One of the things that's making ferry-fare calculation kind of difficult is that ferry fares depend on intermediate stops. Right now, intermediate stops are only given names, which means that [fares are calculated based on](https://github.com/mbta/dotcom/blob/f4eb1fc10f5c9e3b4908054561e0da0b05267d62/lib/dotcom/trip_plan/fares.ex#L115-L121) origin ID, destination ID, and then the names of the intermediate stops. This is bad for a few reasons:
1. Cognitive overhead - why are these names and these ID's?
  1. [This test](https://github.com/mbta/dotcom/blob/f4eb1fc10f5c9e3b4908054561e0da0b05267d62/test/fares/fares_test.exs#L163) seems to think the `between` things are ID's, for instance.
1. The stop names aren't necessarily stable. For instance, the code [is currently looking for](https://github.com/mbta/dotcom/blob/f4eb1fc10f5c9e3b4908054561e0da0b05267d62/lib/fares/fares.ex#L154-L165) stop names "Hingham", "Hull", "Quincy", and "Winthrop", but the stop names are (currently) ["Hingham (Hewitts Cove)"](https://www.mbta.com/stops/Boat-Hingham), ["Hull (Pemberton Point)"](https://www.mbta.com/stops/Boat-Hull), ["Quincy (Squantum Point)"](https://www.mbta.com/stops/Boat-Quincy), and ["Winthrop (Winthrop Landing)"](https://www.mbta.com/stops/Boat-Winthrop).

 Their GTFS ID's are available - let's use them!