### PR TITLE
feat(Schema.FareProduct): parse fare products

### DIFF
--- a/lib/mix/tasks/update_fixture.ex
+++ b/lib/mix/tasks/update_fixture.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.UpdateFixture do
   @moduledoc "Run: `mix update_fixture` to request new data."
   use Mix.Task
 
-  alias OpenTripPlannerClient.{Parser, PlanParams, Request}
+  alias OpenTripPlannerClient.{PlanParams, Request}
 
   @spec run(command_line_args :: [binary]) :: any()
   def run(_) do
@@ -17,10 +17,7 @@ defmodule Mix.Tasks.UpdateFixture do
       })
 
     {:ok, %{body: body}} = Request.plan_connection(params)
-    {:ok, query_result} = Parser.validate_body(body)
-
-    encoded = Jason.encode!(%{"data" => Nestru.encode!(query_result)}, pretty: true)
-
+    encoded = Jason.encode!(body, pretty: true)
     File.write("test/fixture/alewife_to_franklin_park_zoo.json", encoded)
   end
 end

--- a/lib/open_trip_planner_client/parser.ex
+++ b/lib/open_trip_planner_client/parser.ex
@@ -28,8 +28,8 @@ defmodule OpenTripPlannerClient.Parser do
   """
   @spec validate_body(map()) :: {:ok, QueryResult.t()} | {:error, term()}
 
-  def validate_body(%{"errors" => [graphql_error | _]}) do
-    raise GraphQLError, graphql_error
+  def validate_body(%{"errors" => _} = errors) do
+    raise GraphQLError, errors
   end
 
   def validate_body(%{"data" => data}) do

--- a/lib/open_trip_planner_client/schema/fare_product.ex
+++ b/lib/open_trip_planner_client/schema/fare_product.ex
@@ -7,12 +7,50 @@ defmodule OpenTripPlannerClient.Schema.FareProduct do
 
   use OpenTripPlannerClient.Schema
 
-  defimpl Nestru.PreDecoder do
+  alias OpenTripPlannerClient.Schema.{DependentFareProduct, FareProduct}
+
+  defimpl Nestru.PreDecoder, for: FareProduct do
     # credo:disable-for-next-line
     def gather_fields_for_decoding(_, _, %{"product" => product}) do
       updated_map =
         product
+        |> update_in(["dependencies"], &replace_nil_with_list/1)
         |> Map.put("usd_price", get_in(product, ["price", "amount"]))
+        |> Map.put("medium_name", get_in(product, ["medium", "name"]))
+
+      {:ok, updated_map}
+    end
+
+    defp replace_nil_with_list(nil), do: []
+    defp replace_nil_with_list(other), do: other
+  end
+
+  @derive {Nestru.Decoder, hint: %{dependencies: [DependentFareProduct]}}
+  schema do
+    field(:id, String.t(), @nonnull_field)
+    field(:dependencies, [DependentFareProduct.t()])
+    field(:medium_name, String.t())
+    field(:name, String.t(), @nonnull_field)
+    field(:usd_price, float())
+  end
+end
+
+defmodule OpenTripPlannerClient.Schema.DependentFareProduct do
+  @moduledoc """
+  A subset of fields for fare products.
+
+  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/FareProduct
+  """
+
+  use OpenTripPlannerClient.Schema
+
+  alias OpenTripPlannerClient.Schema.DependentFareProduct
+
+  defimpl Nestru.PreDecoder, for: DependentFareProduct do
+    # credo:disable-for-next-line
+    def gather_fields_for_decoding(_, _, product) do
+      updated_map =
+        product
         |> Map.put("medium_name", get_in(product, ["medium", "name"]))
 
       {:ok, updated_map}
@@ -21,8 +59,8 @@ defmodule OpenTripPlannerClient.Schema.FareProduct do
 
   @derive Nestru.Decoder
   schema do
+    field(:id, String.t(), @nonnull_field)
     field(:medium_name, String.t())
-    field(:name, String.t())
-    field(:usd_price, float())
+    field(:name, String.t(), @nonnull_field)
   end
 end

--- a/lib/open_trip_planner_client/schema/fare_product.ex
+++ b/lib/open_trip_planner_client/schema/fare_product.ex
@@ -1,0 +1,28 @@
+defmodule OpenTripPlannerClient.Schema.FareProduct do
+  @moduledoc """
+  A subset of fields for fare products.
+
+  https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/FareProduct
+  """
+
+  use OpenTripPlannerClient.Schema
+
+  defimpl Nestru.PreDecoder do
+    # credo:disable-for-next-line
+    def gather_fields_for_decoding(_, _, %{"product" => product}) do
+      updated_map =
+        product
+        |> Map.put("usd_price", get_in(product, ["price", "amount"]))
+        |> Map.put("medium_name", get_in(product, ["medium", "name"]))
+
+      {:ok, updated_map}
+    end
+  end
+
+  @derive Nestru.Decoder
+  schema do
+    field(:medium_name, String.t())
+    field(:name, String.t())
+    field(:usd_price, float())
+  end
+end

--- a/lib/open_trip_planner_client/schema/leg.ex
+++ b/lib/open_trip_planner_client/schema/leg.ex
@@ -13,8 +13,10 @@ defmodule OpenTripPlannerClient.Schema.Leg do
 
   alias OpenTripPlannerClient.Schema.{
     Agency,
+    FareProduct,
     Geometry,
     IntermediateStop,
+    Leg,
     LegTime,
     Place,
     Route,
@@ -59,11 +61,12 @@ defmodule OpenTripPlannerClient.Schema.Leg do
             |> Code.string_to_quoted!()
           )
 
-  defimpl Nestru.PreDecoder do
+  defimpl Nestru.PreDecoder, for: Leg do
     # credo:disable-for-next-line
     def gather_fields_for_decoding(_, _, map) do
       updated_map =
         map
+        |> update_in(["fare_products"], &replace_nil_with_list/1)
         |> update_in(["intermediate_stops"], &replace_nil_with_list/1)
         |> update_in(["steps"], &replace_nil_with_list/1)
 
@@ -78,6 +81,7 @@ defmodule OpenTripPlannerClient.Schema.Leg do
            hint: %{
              agency: Agency,
              end: LegTime,
+             fare_products: [FareProduct],
              from: Place,
              intermediate_stops: [IntermediateStop],
              leg_geometry: Geometry,
@@ -94,6 +98,7 @@ defmodule OpenTripPlannerClient.Schema.Leg do
     field(:distance, distance_meters())
     field(:duration, duration_seconds())
     field(:end, LegTime.t(), @nonnull_field)
+    field(:fare_products, [FareProduct.t()])
     field(:from, Place.t(), @nonnull_field)
     field(:headsign, String.t())
     field(:interline_with_previous_leg, boolean())

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -65,6 +65,19 @@ fragment PlanInfo on PlanConnection {
         end {
           ...TimeInfo
         }
+        fareProducts {
+          product {
+            ... on DefaultFareProduct {
+              medium {
+                name
+              }
+              name
+              price {
+                amount
+              }
+            }
+          }
+        }
         from {
           ...PlaceInfo
         }

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -7,56 +7,40 @@ query TripPlan(
   $numItineraries: Int
 ) {
   actualPlan: planConnection(
-    origin: $origin,
-    destination: $destination,
-    dateTime: $dateTime,
+    origin: $origin
+    destination: $destination
+    dateTime: $dateTime
     preferences: {
-      accessibility: {
-        wheelchair: {
-          enabled: $wheelchair
-        }
-      },
-      street: {
-        walk: {
-          reluctance: 5.0
-        }
-      },
+      accessibility: { wheelchair: { enabled: $wheelchair } }
+      street: { walk: { reluctance: 5.0 } }
       transit: {
-        filters: [
-          { exclude: [{ agencies: ["mbta-ma-us-initial:1"] }]}
-        ]
+        filters: [{ exclude: [{ agencies: ["mbta-ma-us-initial:1"] }] }]
       }
-    },
-    modes: $modes,
+    }
+    modes: $modes
     searchWindow: "2h"
     first: $numItineraries
-  ) { ...PlanInfo }
+  ) {
+    ...PlanInfo
+  }
 
   idealPlan: planConnection(
-    origin: $origin,
-    destination: $destination,
-    dateTime: $dateTime,
+    origin: $origin
+    destination: $destination
+    dateTime: $dateTime
     preferences: {
-      accessibility: {
-        wheelchair: {
-          enabled: $wheelchair
-        }
-      },
-      street: {
-        walk: {
-          reluctance: 5.0
-        }
-      },
+      accessibility: { wheelchair: { enabled: $wheelchair } }
+      street: { walk: { reluctance: 5.0 } }
       transit: {
-        filters: [
-          { include: [{ agencies: ["mbta-ma-us-initial:1"] }]}
-        ]
+        filters: [{ include: [{ agencies: ["mbta-ma-us-initial:1"] }] }]
       }
-    },
-    modes: $modes,
+    }
+    modes: $modes
     searchWindow: "2h"
     first: $numItineraries
-  ) { ...PlanInfo }
+  ) {
+    ...PlanInfo
+  }
 }
 
 fragment PlanInfo on PlanConnection {
@@ -73,23 +57,33 @@ fragment PlanInfo on PlanConnection {
       end
       generalizedCost
       legs {
-        agency { name }
-        distance
-        duration
-        end { ...TimeInfo }
-        from { ...PlaceInfo }
-        headsign
-        interlineWithPreviousLeg
-        intermediateStops { 
-          gtfsId,
+        agency {
           name
         }
-        legGeometry { points }
+        distance
+        duration
+        end {
+          ...TimeInfo
+        }
+        from {
+          ...PlaceInfo
+        }
+        headsign
+        interlineWithPreviousLeg
+        intermediateStops {
+          gtfsId
+          name
+        }
+        legGeometry {
+          points
+        }
         mode
         realTime
         realtimeState
-        route { 
-          agency { name }
+        route {
+          agency {
+            name
+          }
           gtfsId
           shortName
           longName
@@ -100,14 +94,18 @@ fragment PlanInfo on PlanConnection {
           sortOrder
           mode
         }
-        start { ...TimeInfo }
+        start {
+          ...TimeInfo
+        }
         steps {
           distance
           streetName
           absoluteDirection
           relativeDirection
         }
-        to { ...PlaceInfo }
+        to {
+          ...PlaceInfo
+        }
         transitLeg
         trip {
           directionId
@@ -127,8 +125,8 @@ fragment PlaceInfo on Place {
   name
   lat
   lon
-  stop { 
-    gtfsId, 
+  stop {
+    gtfsId
     name
     url
     vehicleMode

--- a/priv/plan.graphql
+++ b/priv/plan.graphql
@@ -68,10 +68,16 @@ fragment PlanInfo on PlanConnection {
         fareProducts {
           product {
             ... on DefaultFareProduct {
-              medium {
-                name
+              ...FareMediumNameInfo
+              price {
+                amount
               }
-              name
+            }
+            ... on DependentFareProduct {
+              dependencies {
+                ...FareMediumNameInfo
+              }
+              ...FareMediumNameInfo
               price {
                 amount
               }
@@ -157,4 +163,12 @@ fragment TimeInfo on LegTime {
     time
     delay
   }
+}
+
+fragment FareMediumNameInfo on FareProduct {
+  id
+  medium {
+    name
+  }
+  name
 }

--- a/test/fixture/alewife_to_franklin_park_zoo.json
+++ b/test/fixture/alewife_to_franklin_park_zoo.json
@@ -3,4908 +3,7586 @@
     "actual_plan": {
       "itineraries": [
         {
-          "start": "2025-08-14T12:24:53-04:00",
-          "end": "2025-08-14T13:26:59-04:00",
-          "generalized_cost": 8398,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:20:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:26:42-04:00",
-                  "delay": "PT6M42S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:39:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:43:54-04:00",
-                  "delay": "PT4M54S"
-                }
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
+          "node": {
+            "accessibility_score": null,
+            "duration": 3612,
+            "end": "2026-08-14T15:39:05-04:00",
+            "generalized_cost": 7738,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:40:40-04:00"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
                   "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:38:53-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.396148,
-                "lon": -71.140698
+                "transit_leg": false,
+                "trip": null
               },
-              "duration": 1032.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us:Red",
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
+                "distance": 13074.0,
+                "duration": 1377.0,
+                "end": {
+                  "estimated": {
+                    "delay": "PT6M37S",
+                    "time": "2026-08-14T15:03:37-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T14:57:00-04:00"
                 },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69349515",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Braintree",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:43:54-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:45:43-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                "headsign": "Ashmont",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70075",
+                    "name": "Park Street"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70079",
+                    "name": "South Station"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70081",
+                    "name": "Broadway"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]HO~IqQj@cAp@wBr@kBj@kBHYDSnDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCAzlAm@"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:01:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 720.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
                 "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us:Orange",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT8M40S",
+                    "time": "2026-08-14T14:40:40-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T14:32:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76754997",
+                  "trip_headsign": "Ashmont",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 56.2,
+                "duration": 49.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:04:26-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "mrjaGjmupL??\\h@Fo@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:03:37-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 20.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 23.89,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
+                "distance": 4091.0,
+                "duration": 1305.0,
+                "end": {
+                  "estimated": {
+                    "delay": "PT4M45S",
+                    "time": "2026-08-14T15:31:45-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:27:00-04:00"
                 },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69575103",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 5215.25,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:01:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:02:04-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                "headsign": "Forest Hills",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:2905",
+                    "name": "Boston St @ Ellery St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2906",
+                    "name": "Boston St opp Washburn St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2907",
+                    "name": "Boston St @ W Howell St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2908",
+                    "name": "Boston St opp Harvest St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2909",
+                    "name": "Boston St opp Mayhew St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:362",
+                    "name": "Columbia Rd @ Holden St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2910",
+                    "name": "Columbia Rd @ Dudley St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2911",
+                    "name": "Columbia Rd @ Bird St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2912",
+                    "name": "Columbia Rd @ Glendale St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2913",
+                    "name": "Columbia Rd @ Quincy St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2914",
+                    "name": "Columbia Rd @ Hamilton St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2915",
+                    "name": "Columbia Rd opp Wyola Pl"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2916",
+                    "name": "Columbia Rd @ Devon St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2918",
+                    "name": "Columbia Rd @ Geneva Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2919",
+                    "name": "Columbia Rd @ Washington St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2920",
+                    "name": "Columbia Rd @ Seaver St"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J??lA\\\\LXJj@RVNRL`BfA~@l@??n@`@|@h@dAr@n@`@~@`@tA^XF??x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@??VPrBnAp@b@\\^t@`AXj@JV??Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@??NHdD|ArBbAjAj@??NF\\ZtBbCdAtA\\h@\\v@P^l@xAdAtCd@~@h@dA??JPpAbCZf@PVf@x@h@dAtA`Ct@nABB`@h@l@x@|AlBTX@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ??FTDp@Z|BTrANh@Vn@b@|@??HRPZ|@~ATj@v@xAj@z@Zl@JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "duration": 64.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
-              },
-              "steps": [
-                {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "trip": null,
-              "distance": 71.02,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:11:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T13:09:20-04:00",
-                  "delay": "-PT1M40S"
-                }
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-08-14T13:19:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T13:18:55-04:00",
-                  "delay": "-PT5S"
-                }
-              },
-              "to": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "duration": 575.0,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
                 "mode": "BUS",
-                "desc": "Frequent Bus",
-                "color": "FFC72C",
-                "sort_order": 50220,
-                "gtfs_id": "mbta-ma-us:22",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "22",
-                "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Columbus Ave @ Dimock St"
-                },
-                {
-                  "name": "Columbus Ave opp Bray St"
-                },
-                {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
-                },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
-                },
-                {
-                  "name": "Seaver St opp Harold St"
-                },
-                {
-                  "name": "Seaver St opp Humboldt Ave"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69703873",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 2101.86,
-              "headsign": "Ashmont",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:18:55-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:26:59-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "duration": 484.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 244.74,
-                  "absolute_direction": "WEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 608.11,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 947.36,
-          "number_of_transfers": 2,
-          "duration": 3726,
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-08-14T12:24:53-04:00",
-          "end": "2025-08-14T13:29:14-04:00",
-          "generalized_cost": 11658,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:20:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:26:42-04:00",
-                  "delay": "PT6M42S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:39:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:43:54-04:00",
-                  "delay": "PT4M54S"
-                }
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1032.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69349515",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Braintree",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:43:54-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:45:43-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:04:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 900.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us:Orange",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
-                },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                },
-                {
-                  "name": "Jackson Square"
-                },
-                {
-                  "name": "Stony Brook"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69575103",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 6857.3,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:04:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:29:14-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "duration": 1514.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 67.67,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 19.37,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 11.89,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
-                },
-                {
-                  "distance": 170.33,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "sidewalk"
-                },
-                {
-                  "distance": 5.09,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Union Avenue"
-                },
-                {
-                  "distance": 102.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "Green Street"
-                },
-                {
-                  "distance": 420.06,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "Glen Road"
-                },
-                {
-                  "distance": 318.77,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "SLIGHTLY_RIGHT",
-                  "street_name": "Glen Lane"
-                },
-                {
-                  "distance": 155.39,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "bike path"
-                },
-                {
-                  "distance": 294.71,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Pierpont Road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 1929.63,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 2197.86,
-          "number_of_transfers": 1,
-          "duration": 3861,
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-08-14T12:32:02-04:00",
-          "end": "2025-08-14T13:36:14-04:00",
-          "generalized_cost": 11649,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:30:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:33:51-04:00",
-                  "delay": "PT3M51S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:51:03-04:00",
-                  "delay": "PT2M3S"
-                }
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1032.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69349516",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Braintree",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:51:03-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:52:52-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:56:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:11:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 900.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us:Orange",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
-                },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                },
-                {
-                  "name": "Jackson Square"
-                },
-                {
-                  "name": "Stony Brook"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69575109",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 6857.3,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:11:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:36:14-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "duration": 1514.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 67.67,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 19.37,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 11.89,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
-                },
-                {
-                  "distance": 170.33,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "sidewalk"
-                },
-                {
-                  "distance": 5.09,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Union Avenue"
-                },
-                {
-                  "distance": 102.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "Green Street"
-                },
-                {
-                  "distance": 420.06,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "Glen Road"
-                },
-                {
-                  "distance": 318.77,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "SLIGHTLY_RIGHT",
-                  "street_name": "Glen Lane"
-                },
-                {
-                  "distance": 155.39,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "bike path"
-                },
-                {
-                  "distance": 294.71,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Pierpont Road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 1929.63,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 2197.86,
-          "number_of_transfers": 1,
-          "duration": 3852,
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-08-14T12:32:02-04:00",
-          "end": "2025-08-14T13:37:01-04:00",
-          "generalized_cost": 7280,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:30:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:33:51-04:00",
-                  "delay": "PT3M51S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:55:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:57:09-04:00",
-                  "delay": "PT2M9S"
-                }
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1398.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                },
-                {
-                  "name": "Downtown Crossing"
-                },
-                {
-                  "name": "South Station"
-                },
-                {
-                  "name": "Broadway"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69349516",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 13074.0,
-              "headsign": "Braintree",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:57:09-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:57:59-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "duration": 50.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "mrjaGjmupL??\\h@Fo@"
-              },
-              "steps": [
-                {
-                  "distance": 20.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 23.89,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "trip": null,
-              "distance": 56.2,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:06:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T13:06:00-04:00",
-                  "delay": "PT0S"
-                }
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-08-14T13:33:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T13:29:49-04:00",
-                  "delay": "-PT3M11S"
-                }
-              },
-              "to": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us:16",
+                  "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                  "mode": "BUS",
+                  "short_name": "16",
+                  "sort_order": 50160,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT0S",
+                    "time": "2026-08-14T15:10:00-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:10:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
                   "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-andrw"
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "duration": 1429.0,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "sort_order": 50160,
-                "gtfs_id": "mbta-ma-us:16",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "16",
-                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "South Bay Mall @ Target"
-                },
-                {
-                  "name": "South Bay Mall opp Macy's"
-                },
-                {
-                  "name": "South Bay Mall @ Allstate Rd"
-                },
-                {
-                  "name": "Massachusetts Ave opp Clapp St"
-                },
-                {
-                  "name": "Massachusetts Ave @ Columbia Rd"
-                },
-                {
-                  "name": "Columbia Rd @ Holden St"
-                },
-                {
-                  "name": "Columbia Rd @ Dudley St"
-                },
-                {
-                  "name": "Columbia Rd @ Bird St"
-                },
-                {
-                  "name": "Columbia Rd @ Glendale St"
-                },
-                {
-                  "name": "Columbia Rd @ Quincy St"
-                },
-                {
-                  "name": "Columbia Rd @ Hamilton St"
-                },
-                {
-                  "name": "Columbia Rd opp Wyola Pl"
-                },
-                {
-                  "name": "Columbia Rd @ Devon St"
-                },
-                {
-                  "name": "Columbia Rd @ Geneva Ave"
-                },
-                {
-                  "name": "Columbia Rd @ Washington St"
-                },
-                {
-                  "name": "Columbia Rd @ Seaver St"
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:77172413",
+                  "trip_headsign": "Forest Hills",
+                  "trip_short_name": null
                 }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "arjaGdmupL?cCd@An@?`@Jm@tFm@jECR[hDWnBQ~ASbBAFg@lEET?VJRHPb@FNCHIHEDKBQ?iAA[?????Y@e@Dg@FSFOLQb@c@bB}ATQPGLAP?RBVFTHhFbCz@b@????tCzAXP\\RFD??FD^t@FPBPCXGn@T?NDRPh@nAHn@j@tAt@tBJIj@_@hByAn@g@r@o@JI??jAeAfEgD|BgBrAeA????~@s@X[NUD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
               },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69702406",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills via South Bay Center",
-                "trip_short_name": null
-              },
-              "distance": 5043.52,
-              "headsign": "Forest Hills via South Bay Center",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:29:49-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:37:01-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
+              {
+                "agency": null,
+                "distance": 533.36,
+                "duration": 440.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:39:05-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
                   "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
+                  }
                 },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "duration": 432.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 34.79,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Franklin Park Road"
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
                 },
-                {
-                  "distance": 13.01,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:31:45-04:00"
                 },
-                {
-                  "distance": 51.01,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 34.79,
+                    "relative_direction": "DEPART",
+                    "street_name": "Franklin Park Road"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 13.01,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 51.01,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 305.25,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
                 },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 520.79,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 715.0699999999999,
-          "number_of_transfers": 1,
-          "duration": 3899,
-          "accessibility_score": null
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 1,
+            "start": "2026-08-14T14:38:53-04:00",
+            "walk_distance": 727.6400000000001
+          }
         },
         {
-          "start": "2025-08-14T12:38:18-04:00",
-          "end": "2025-08-14T13:42:58-04:00",
-          "generalized_cost": 8552,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:36:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:40:07-04:00",
-                  "delay": "PT4M7S"
-                }
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:55:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T12:57:19-04:00",
-                  "delay": "PT2M19S"
-                }
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
+          "node": {
+            "accessibility_score": null,
+            "duration": 3789,
+            "end": "2026-08-14T15:44:02-04:00",
+            "generalized_cost": 8515,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:42:40-04:00"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
                   "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-alfcl"
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:40:53-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.396148,
-                "lon": -71.140698
+                "transit_leg": false,
+                "trip": null
               },
-              "duration": 1032.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us:Red",
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
+                "distance": 13074.0,
+                "duration": 1377.0,
+                "end": {
+                  "estimated": {
+                    "delay": "PT3M37S",
+                    "time": "2026-08-14T15:05:37-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:02:00-04:00"
                 },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69349297",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Ashmont",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:57:19-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:59:08-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70075",
+                    "name": "Park Street"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70079",
+                    "name": "South Station"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70081",
+                    "name": "Broadway"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]HO~IqQj@cAp@wBr@kBj@kBHYDSnDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCAzlAm@"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:03:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:15:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 720.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
                 "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us:Orange",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT5M40S",
+                    "time": "2026-08-14T14:42:40-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T14:37:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76755298",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 56.2,
+                "duration": 49.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:06:26-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "mrjaGjmupL??\\h@Fo@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:05:37-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 20.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 23.89,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
+                "distance": 1463.0,
+                "duration": 300.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:18:00-04:00"
                 },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69575115",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 5215.25,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:15:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:16:04-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
+                "headsign": "Fields Corner",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:2905",
+                    "name": "Boston St @ Ellery St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2906",
+                    "name": "Boston St opp Washburn St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2907",
+                    "name": "Boston St @ W Howell St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2908",
+                    "name": "Boston St opp Harvest St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2909",
+                    "name": "Boston St opp Mayhew St"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J??lA\\\\LXJj@RVNRL`BfA~@l@??n@`@|@h@dAr@n@`@~@`@tA^XF??x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@"
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "duration": 64.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
-              },
-              "steps": [
-                {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "trip": null,
-              "distance": 71.02,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:26:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T13:25:23-04:00",
-                  "delay": "-PT37S"
-                }
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-08-14T13:34:00-04:00",
-                "estimated": {
-                  "time": "2025-08-14T13:34:54-04:00",
-                  "delay": "PT54S"
-                }
-              },
-              "to": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "duration": 571.0,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
                 "mode": "BUS",
-                "desc": "Frequent Bus",
-                "color": "FFC72C",
-                "sort_order": 50220,
-                "gtfs_id": "mbta-ma-us:22",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us:17",
+                  "long_name": "Fields Corner Station - Andrew Station",
+                  "mode": "BUS",
+                  "short_name": "17",
+                  "sort_order": 50170,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:13:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.318764,
+                  "lon": -71.063583,
+                  "name": "Columbia Rd @ Holden St",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:362",
+                    "name": "Columbia Rd @ Holden St",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/362",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76572365",
+                  "trip_headsign": "Fields Corner",
+                  "trip_short_name": null
+                }
+              },
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": "22",
-                "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "UPDATED",
-              "intermediate_stops": [
-                {
-                  "name": "Columbus Ave @ Dimock St"
+                "distance": 2627.0,
+                "duration": 866.0,
+                "end": {
+                  "estimated": {
+                    "delay": "-PT9M18S",
+                    "time": "2026-08-14T15:36:42-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:46:00-04:00"
                 },
-                {
-                  "name": "Columbus Ave opp Bray St"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.318764,
+                  "lon": -71.063583,
+                  "name": "Columbia Rd @ Holden St",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:362",
+                    "name": "Columbia Rd @ Holden St",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/362",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
                 },
-                {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
+                "headsign": "Forest Hills via South Bay Center",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:2910",
+                    "name": "Columbia Rd @ Dudley St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2911",
+                    "name": "Columbia Rd @ Bird St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2912",
+                    "name": "Columbia Rd @ Glendale St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2913",
+                    "name": "Columbia Rd @ Quincy St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2914",
+                    "name": "Columbia Rd @ Hamilton St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2915",
+                    "name": "Columbia Rd opp Wyola Pl"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2916",
+                    "name": "Columbia Rd @ Devon St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2918",
+                    "name": "Columbia Rd @ Geneva Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2919",
+                    "name": "Columbia Rd @ Washington St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:2920",
+                    "name": "Columbia Rd @ Seaver St"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "_khaGxqvpL??VPrBnAp@b@\\^t@`AXj@JV??Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@??NHdD|ArBbAjAj@??NF\\ZtBbCdAtA\\h@\\v@P^l@xAdAtCd@~@h@dA??JPpAbCZf@PVf@x@h@dAtA`Ct@nABB`@h@l@x@|AlBTX@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ??FTDp@Z|BTrANh@Vn@b@|@??HRPZ|@~ATj@v@xAj@z@Zl@JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
                 },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
+                "mode": "BUS",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us:16",
+                  "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                  "mode": "BUS",
+                  "short_name": "16",
+                  "sort_order": 50160,
+                  "text_color": "000000",
+                  "type": 3
                 },
-                {
-                  "name": "Seaver St opp Harold St"
+                "start": {
+                  "estimated": {
+                    "delay": "-PT1M44S",
+                    "time": "2026-08-14T15:22:16-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:24:00-04:00"
                 },
-                {
-                  "name": "Seaver St opp Humboldt Ave"
+                "steps": [],
+                "to": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76573772",
+                  "trip_headsign": "Forest Hills via South Bay Center",
+                  "trip_short_name": null
                 }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
               },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us:69703874",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
+              {
+                "agency": null,
+                "distance": 533.36,
+                "duration": 440.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:44:02-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:36:42-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 34.79,
+                    "relative_direction": "DEPART",
+                    "street_name": "Franklin Park Road"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 13.01,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 51.01,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 305.25,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 2,
+            "start": "2026-08-14T14:40:53-04:00",
+            "walk_distance": 727.6400000000001
+          }
+        },
+        {
+          "node": {
+            "accessibility_score": null,
+            "duration": 3729,
+            "end": "2026-08-14T15:45:55-04:00",
+            "generalized_cost": 9197,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:45:33-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:43:46-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
               },
-              "distance": 2101.86,
-              "headsign": "Ashmont",
-              "real_time": true
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:34:54-04:00",
-                "estimated": null
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 9821.0,
+                "duration": 1040.0,
+                "end": {
+                  "estimated": {
+                    "delay": "PT1M53S",
+                    "time": "2026-08-14T15:02:53-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:01:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Ashmont",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70075",
+                    "name": "Park Street"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]"
+                },
+                "mode": "SUBWAY",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT3M33S",
+                    "time": "2026-08-14T14:45:33-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T14:42:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76755003",
+                  "trip_headsign": "Ashmont",
+                  "trip_short_name": null
+                }
               },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:42:58-04:00",
-                "estimated": null
+              {
+                "agency": null,
+                "distance": 130.15,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:04:40-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}poaGl}upL????????"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:02:53-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 36.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Concourse | CharlieCard Store"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 77.57,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 16.46,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  }
+                ],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
               },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 5215.0,
+                "duration": 613.0,
+                "end": {
+                  "estimated": {
+                    "delay": "PT1S",
+                    "time": "2026-08-14T15:20:01-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:20:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Forest Hills",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70018",
+                    "name": "Chinatown"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70016",
+                    "name": "Tufts Medical Center"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70014",
+                    "name": "Back Bay"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70012",
+                    "name": "Massachusetts Avenue"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70010",
+                    "name": "Ruggles"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70008",
+                    "name": "Roxbury Crossing"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@?P@fD`@|B^XJRLx@`AzBvB^F\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvAfB`ClN`RfAtApCrD`@j@RVRT`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfAjBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
+                },
+                "mode": "SUBWAY",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "ED8B00",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Orange",
+                  "long_name": "Orange Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10020,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT48S",
+                    "time": "2026-08-14T15:09:48-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:09:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.323132,
+                  "lon": -71.099592,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70006",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:78494253",
+                  "trip_headsign": "Forest Hills",
+                  "trip_short_name": null
+                }
               },
-              "from": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
+              {
+                "agency": null,
+                "distance": 71.02,
+                "duration": 63.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:21:04-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.323132,
+                  "lon": -71.099592,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70006",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "qfiaGns}pL????????Vv@KaA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:20:01-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 41.15,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 9.14,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 8.53,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to buses, Centre Street"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.323074,
+                  "lon": -71.099546,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:11531",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 2101.0,
+                "duration": 594.0,
+                "end": {
+                  "estimated": {
+                    "delay": "-PT2M16S",
+                    "time": "2026-08-14T15:37:44-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:40:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.323074,
+                  "lon": -71.099546,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:11531",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": "Ashmont",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:1265",
+                    "name": "Columbus Ave @ Dimock St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:1266",
+                    "name": "Columbus Ave opp Bray St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:10413",
+                    "name": "Columbus Ave @ Weld Ave - Egleston Sq"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:11413",
+                    "name": "Columbus Ave @ Walnut Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:17421",
+                    "name": "Seaver St opp Harold St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:17411",
+                    "name": "Seaver St opp Humboldt Ave"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCCl@?fBA~BEv@A~BAxBAzDGZ?NARCHEJGRSf@y@v@iADI??HOhAgBt@gAr@iApAsBNU??b@m@f@_ATi@XeAL]L[TUZUb@U@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]??PYxB_Dv@kAxB_DhBgCFK"
+                },
+                "mode": "BUS",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Frequent Bus",
+                  "gtfs_id": "mbta-ma-us:22",
+                  "long_name": "Ashmont Station - Ruggles Station via Talbot Avenue",
+                  "mode": "BUS",
+                  "short_name": "22",
+                  "sort_order": 50220,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "-PT3M10S",
+                    "time": "2026-08-14T15:27:50-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:31:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.307515,
+                  "lon": -71.089263,
                   "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:17401",
+                    "name": "Seaver St opp Elm Hill Ave",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/17401",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
                 },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "duration": 484.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 244.74,
-                  "absolute_direction": "WEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76573649",
+                  "trip_headsign": "Ashmont",
+                  "trip_short_name": null
                 }
-              ],
-              "trip": null,
-              "distance": 608.11,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 947.36,
-          "number_of_transfers": 2,
-          "duration": 3880,
-          "accessibility_score": null
+              },
+              {
+                "agency": null,
+                "distance": 626.45,
+                "duration": 491.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:45:55-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.307515,
+                  "lon": -71.089263,
+                  "name": "Seaver St opp Elm Hill Ave",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:17401",
+                    "name": "Seaver St opp Elm Hill Ave",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/17401",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@FAFEHId@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?DFBD@F?F@B?DB??B@BVGJQLg@LYNGLg@d@CFJDJF@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:37:44-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 244.74,
+                    "relative_direction": "DEPART",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHEAST",
+                    "distance": 99.91,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 89.98,
+                    "relative_direction": "RIGHT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 12.65,
+                    "relative_direction": "RIGHT",
+                    "street_name": "open area"
+                  },
+                  {
+                    "absolute_direction": "SOUTHEAST",
+                    "distance": 34.46,
+                    "relative_direction": "LEFT",
+                    "street_name": "open area"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 144.73,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 2,
+            "start": "2026-08-14T14:43:46-04:00",
+            "walk_distance": 965.7
+          }
+        },
+        {
+          "node": {
+            "accessibility_score": null,
+            "duration": 3807,
+            "end": "2026-08-14T15:49:45-04:00",
+            "generalized_cost": 11292,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:48:05-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:46:18-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 10360.0,
+                "duration": 1126.0,
+                "end": {
+                  "estimated": {
+                    "delay": "-PT1M9S",
+                    "time": "2026-08-14T15:06:51-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:08:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70075",
+                    "name": "Park Street"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]HO~IqQj@cAp@wBr@kBj@kBHYDS"
+                },
+                "mode": "SUBWAY",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT1M5S",
+                    "time": "2026-08-14T14:48:05-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T14:47:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.352271,
+                  "lon": -71.055242,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70079",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76755299",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 178.88,
+                "duration": 133.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:09:04-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.352271,
+                  "lon": -71.055242,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70079",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "u|naGh~tpLYeA???FQb@dAPNGj@Qd@O^J"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:06:51-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "NORTHEAST",
+                    "distance": 47.85,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Commuter Rail, Amtrak, SL4 | Exits"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "HARD_RIGHT",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 6.1,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Bus Terminal, lobby, Amtrak, Silver Line - SL4 Nubian, Commuter Rail"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 17.63,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exits | SL4, Bus Terminal, Commuter Rail, Amtrak"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.83,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Bus Terminal, Commuter Rail, Amtrak, restrooms | Exits"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 9.46,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Tickets, information | Exits | Commuter Rail, Amtrak, Bus Terminal"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 23.77,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Commuter Rail, Amtrak, Bus Terminal"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 22.25,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - All trains, Silver Line - SL1/SL2/SL3 | Elevators"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 17.98,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Commuter Rail"
+                  }
+                ],
+                "to": {
+                  "lat": 42.351497,
+                  "lon": -71.055059,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:NEC-2287",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 5711.0,
+                "duration": 780.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:30:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_cr_zone_1a",
+                      "medium": {
+                        "name": "Credit/debit card"
+                      },
+                      "name": "Commuter Rail Zone 1A one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_cr_zone_1a",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Commuter Rail Zone 1A one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_cr_zone_1a",
+                      "medium": {
+                        "name": "mTicket app"
+                      },
+                      "name": "Commuter Rail Zone 1A one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.351497,
+                  "lon": -71.055059,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:NEC-2287",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "headsign": "Readville via Fairmount",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:DB-2265-01",
+                    "name": "Newmarket"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:DB-2258-01",
+                    "name": "Uphams Corner"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "wwnaGz{tpL\\BjL~Er@XpDbBl@Zh@\\t@^hAp@fBfAvDzBvEnCFFHDJHjBdApAv@tAf@p@Nj@NLDPFR@b@@V?~@Av@A`AAhAAnDK|DGdHMxBEXDp@N`@Nh@XrAt@|A~@NJlE|BhBfAlAl@zAx@n@Z`@Rb@Rz@f@`@TbB~@f@T|@j@jCtAhFtCfCtA`B|@nCxApAp@JFXL|B`AtAd@dAVnAVpAVtBZdATjGfAbANpEv@rARdCb@HBfANXD`Et@F@`BZxA\\v@ThA^`Ab@tAh@fGbC~Al@PFFBZJtAh@fBt@`A^`C`AtCfAfA^~@`@bA`@\\LdChA|@f@v@d@`At@~@|@v@z@z@dAjBxBbCvCxA`Bx@bAr@t@v@v@v@l@FDLH"
+                },
+                "mode": "RAIL",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "80276C",
+                  "desc": "Regional Rail",
+                  "gtfs_id": "mbta-ma-us:CR-Fairmount",
+                  "long_name": "Fairmount Line",
+                  "mode": "RAIL",
+                  "short_name": null,
+                  "sort_order": 20001,
+                  "text_color": "FFFFFF",
+                  "type": 2
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:17:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.303955,
+                  "lon": -71.077979,
+                  "name": "Four Corners/Geneva",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:DB-2249-01",
+                    "name": "Four Corners/Geneva",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-DB-2249"
+                    },
+                    "url": "https://www.mbta.com/stops/place-DB-2249",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:Tower1Aug14-845698-1659",
+                  "trip_headsign": "Readville",
+                  "trip_short_name": "1659"
+                }
+              },
+              {
+                "agency": null,
+                "distance": 1445.71,
+                "duration": 1185.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:49:45-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.303955,
+                  "lon": -71.077979,
+                  "name": "Four Corners/Geneva",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:DB-2249-01",
+                    "name": "Four Corners/Geneva",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-DB-2249"
+                    },
+                    "url": "https://www.mbta.com/stops/place-DB-2249",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "speaG|jypL~BbB?BTt@sA~@BLDN@@WRoA|@]b@A@CBEF_C|CjA~BDHDH~@fBz@pAJPDFFHfAtADHFHLVFPFRBJBPBJ@JFb@BZ@^?n@CL@FAJAH?B@LBN@|@?BAH?B?DA??F@RBf@?L@D?BJNnAfCCBCDKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:30:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 82.3,
+                    "relative_direction": "DEPART",
+                    "street_name": "Track 1 (Outbound)"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 27.05,
+                    "relative_direction": "SLIGHTLY_RIGHT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 53.95,
+                    "relative_direction": "RIGHT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 209.68,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 587.16,
+                    "relative_direction": "LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 51.01,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 305.25,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 1,
+            "start": "2026-08-14T14:46:18-04:00",
+            "walk_distance": 1762.67
+          }
+        },
+        {
+          "node": {
+            "accessibility_score": null,
+            "duration": 3886,
+            "end": "2026-08-14T15:51:04-04:00",
+            "generalized_cost": 9641,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:48:05-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:46:18-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 9821.0,
+                "duration": 1040.0,
+                "end": {
+                  "estimated": {
+                    "delay": "-PT35S",
+                    "time": "2026-08-14T15:05:25-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:06:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70075",
+                    "name": "Park Street"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]"
+                },
+                "mode": "SUBWAY",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT1M5S",
+                    "time": "2026-08-14T14:48:05-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T14:47:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:76755299",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 130.15,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:07:12-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}poaGl}upL????????"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:05:25-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 36.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Concourse | CharlieCard Store"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 77.57,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 16.46,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  }
+                ],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 7967.0,
+                "duration": 888.0,
+                "end": {
+                  "estimated": {
+                    "delay": "-PT1M24S",
+                    "time": "2026-08-14T15:29:36-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:31:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Forest Hills",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:70018",
+                    "name": "Chinatown"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70016",
+                    "name": "Tufts Medical Center"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70014",
+                    "name": "Back Bay"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70012",
+                    "name": "Massachusetts Avenue"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70010",
+                    "name": "Ruggles"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70008",
+                    "name": "Roxbury Crossing"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70006",
+                    "name": "Jackson Square"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70004",
+                    "name": "Stony Brook"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:70002",
+                    "name": "Green Street"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@?P@fD`@|B^XJRLx@`AzBvB^F\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvAfB`ClN`RfAtApCrD`@j@RVRT`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfAjBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@Rp@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVLLFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@jBdA|@f@f@Zx@h@fDhBHFnFvCbAl@xC`B|BrAxA~@zClBrA|@hBhANJj@d@NJPJlDtBl@^"
+                },
+                "mode": "SUBWAY",
+                "real_time": true,
+                "realtime_state": "UPDATED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "ED8B00",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us:Orange",
+                  "long_name": "Orange Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10020,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": {
+                    "delay": "PT48S",
+                    "time": "2026-08-14T15:14:48-04:00"
+                  },
+                  "scheduled_time": "2026-08-14T15:14:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.300926,
+                  "lon": -71.114129,
+                  "name": "Forest Hills",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70001",
+                    "name": "Forest Hills",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-forhl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-forhl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us:78494261",
+                  "trip_headsign": "Forest Hills",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 117.46,
+                "duration": 88.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:31:04-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.300926,
+                  "lon": -71.114129,
+                  "name": "Forest Hills",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:70001",
+                    "name": "Forest Hills",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-forhl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-forhl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "w{daGhn`qLCSPJTC??X{@MYOIx@H"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:29:36-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 9.75,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses, Parking, Lobby, Commuter Rail"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 71.58,
+                    "relative_direction": "HARD_RIGHT",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 36.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.300479,
+                  "lon": -71.113634,
+                  "name": "Forest Hills",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:875",
+                    "name": "Forest Hills",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-forhl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-forhl",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 2795.0,
+                "duration": 420.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:43:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.300479,
+                  "lon": -71.113634,
+                  "name": "Forest Hills",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:875",
+                    "name": "Forest Hills",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us:place-forhl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-forhl",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": "Andrew via South Bay Center",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us:520",
+                    "name": "Arborway @ Courthouse"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:522",
+                    "name": "Circuit Dr @ Shattuck Hospital"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us:10522",
+                    "name": "Circuit Dr @ Glen Ln"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "wxdaGtj`qLj@XR?Vc@w@a@wA_Ak@a@oAq@?c@Ao@K{CCqCDaG?IBkAH}@Fi@Pu@TaApB_FQUc@o@KQIQCSUkAQaBG{BBkADm@RuA\\oB??@CDg@@[Ae@Cc@GYQUOMUKoBe@]Q{@s@[]uAiBo@kAs@cBm@wAu@kBUaAQ}A[wBUqAq@uCYgAQc@_@s@Q[_@}@Oi@AMIq@Ao@@cA@WNcATgAVaA`@}@r@qAZa@f@e@b@YnBiAv@a@`@U`@]v@aAd@}@^aARw@Nq@N}@Bq@?c@Ei@Gq@Uy@Qq@CUBSHQT_@Pe@Da@"
+                },
+                "mode": "BUS",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us:16",
+                  "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                  "mode": "BUS",
+                  "short_name": "16",
+                  "sort_order": 50160,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:36:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.301806,
+                  "lon": -71.086667,
+                  "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:2922",
+                    "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/2922",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "1",
+                  "gtfs_id": "mbta-ma-us:76573042",
+                  "trip_headsign": "Andrew via South Bay Center",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 596.41,
+                "duration": 484.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:51:04-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.301806,
+                  "lon": -71.086667,
+                  "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us:2922",
+                    "name": "Glen Ln @ Blue Hill Ave - Franklin Park Zoo",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/2922",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "gaeaGtb{pL@FAHQE?BCJCJEJEJO`@KJEDEBE@C?C?ECECCGGIO_@MDGDGBi@l@SVKSACEIIRc@d@[\\a@`@GHaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:43:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 4.43,
+                    "relative_direction": "DEPART",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "NORTH",
+                    "distance": 9.92,
+                    "relative_direction": "RIGHT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 41.18,
+                    "relative_direction": "LEFT",
+                    "street_name": "Franklin Park Road"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 40.89,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "road"
+                  },
+                  {
+                    "absolute_direction": "NORTHEAST",
+                    "distance": 15.78,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "Franklin Park Road"
+                  },
+                  {
+                    "absolute_direction": "NORTH",
+                    "distance": 80.48,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 274.42,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 2,
+            "start": "2026-08-14T14:46:18-04:00",
+            "walk_distance": 982.0999999999999
+          }
         }
       ],
       "routing_errors": [],
-      "search_date_time": "2025-08-14T12:22:04-04:00"
+      "search_date_time": "2026-08-14T14:31:40-04:00"
     },
     "ideal_plan": {
       "itineraries": [
         {
-          "start": "2025-08-14T12:23:11-04:00",
-          "end": "2025-08-14T13:27:04-04:00",
-          "generalized_cost": 8505,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:25:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:44:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
+          "node": {
+            "accessibility_score": null,
+            "duration": 3547,
+            "end": "2026-08-14T15:34:20-04:00",
+            "generalized_cost": 7673,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:37:00-04:00"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
                   "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:35:13-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.396148,
-                "lon": -71.140698
+                "transit_leg": false,
+                "trip": null
               },
-              "duration": 1140.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
+                "distance": 13074.0,
+                "duration": 1.5e3,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:02:00-04:00"
                 },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349296",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Ashmont",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:44:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:45:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70075",
+                    "name": "Park Street"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70079",
+                    "name": "South Station"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70081",
+                    "name": "Broadway"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]HO~IqQj@cAp@wBr@kBj@kBHYDSnDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCAzlAm@"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:01:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 720.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
                 "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us-initial:Orange",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:37:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76755298",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 56.2,
+                "duration": 49.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:02:49-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "mrjaGjmupL??\\h@Fo@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:02:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 20.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 23.89,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
+                "distance": 4091.0,
+                "duration": 1020.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:27:00-04:00"
                 },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575103",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 5215.25,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:01:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:02:04-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                "headsign": "Forest Hills",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2905",
+                    "name": "Boston St @ Ellery St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2906",
+                    "name": "Boston St opp Washburn St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2907",
+                    "name": "Boston St @ W Howell St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2908",
+                    "name": "Boston St opp Harvest St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2909",
+                    "name": "Boston St opp Mayhew St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:362",
+                    "name": "Columbia Rd @ Holden St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2910",
+                    "name": "Columbia Rd @ Dudley St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2911",
+                    "name": "Columbia Rd @ Bird St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2912",
+                    "name": "Columbia Rd @ Glendale St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2913",
+                    "name": "Columbia Rd @ Quincy St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2914",
+                    "name": "Columbia Rd @ Hamilton St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2915",
+                    "name": "Columbia Rd opp Wyola Pl"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2916",
+                    "name": "Columbia Rd @ Devon St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2918",
+                    "name": "Columbia Rd @ Geneva Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2919",
+                    "name": "Columbia Rd @ Washington St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2920",
+                    "name": "Columbia Rd @ Seaver St"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J??lA\\\\LXJj@RVNRL`BfA~@l@??n@`@|@h@dAr@n@`@~@`@tA^XF??x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@??VPrBnAp@b@\\^t@`AXj@JV??Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@??NHdD|ArBbAjAj@??NF\\ZtBbCdAtA\\h@\\v@P^l@xAdAtCd@~@h@dA??JPpAbCZf@PVf@x@h@dAtA`Ct@nABB`@h@l@x@|AlBTX@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ??FTDp@Z|BTrANh@Vn@b@|@??HRPZ|@~ATj@v@xAj@z@Zl@JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "duration": 64.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
-              },
-              "steps": [
-                {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "trip": null,
-              "distance": 71.02,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:11:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-08-14T13:19:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us-initial:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "duration": 480.0,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
                 "mode": "BUS",
-                "desc": "Frequent Bus",
-                "color": "FFC72C",
-                "sort_order": 50220,
-                "gtfs_id": "mbta-ma-us-initial:22",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "22",
-                "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Columbus Ave @ Dimock St"
-                },
-                {
-                  "name": "Columbus Ave opp Bray St"
-                },
-                {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
-                },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
-                },
-                {
-                  "name": "Seaver St opp Harold St"
-                },
-                {
-                  "name": "Seaver St opp Humboldt Ave"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69703873",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 2101.86,
-              "headsign": "Ashmont",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:19:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:27:04-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us-initial:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "duration": 484.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 244.74,
-                  "absolute_direction": "WEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 608.11,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 947.36,
-          "number_of_transfers": 2,
-          "duration": 3833,
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-08-14T12:23:11-04:00",
-          "end": "2025-08-14T13:29:14-04:00",
-          "generalized_cost": 11760,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:25:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:44:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1140.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349296",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Ashmont",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:44:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:45:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:04:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us-initial:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 900.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us-initial:Orange",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
-                },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                },
-                {
-                  "name": "Jackson Square"
-                },
-                {
-                  "name": "Stony Brook"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575103",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 6857.3,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:04:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:29:14-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us-initial:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "duration": 1514.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 67.67,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 19.37,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 11.89,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
-                },
-                {
-                  "distance": 170.33,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "sidewalk"
-                },
-                {
-                  "distance": 5.09,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Union Avenue"
-                },
-                {
-                  "distance": 102.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "Green Street"
-                },
-                {
-                  "distance": 420.06,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "Glen Road"
-                },
-                {
-                  "distance": 318.77,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "SLIGHTLY_RIGHT",
-                  "street_name": "Glen Lane"
-                },
-                {
-                  "distance": 155.39,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "bike path"
-                },
-                {
-                  "distance": 294.71,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Pierpont Road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 1929.63,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 2197.86,
-          "number_of_transfers": 1,
-          "duration": 3963,
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-08-14T12:28:11-04:00",
-          "end": "2025-08-14T13:36:14-04:00",
-          "generalized_cost": 11880,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:30:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1140.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349516",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Braintree",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:49:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:50:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:56:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:11:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us-initial:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 900.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us-initial:Orange",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
-                },
-                {
-                  "name": "Tufts Medical Center"
-                },
-                {
-                  "name": "Back Bay"
-                },
-                {
-                  "name": "Massachusetts Avenue"
-                },
-                {
-                  "name": "Ruggles"
-                },
-                {
-                  "name": "Roxbury Crossing"
-                },
-                {
-                  "name": "Jackson Square"
-                },
-                {
-                  "name": "Stony Brook"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R??p@\\NFPLh@\\PLtA|@lA|@~AhAvCbCdDpCpA~@hC`Bt@b@xAt@jAj@VLJDVL??LFvBz@fA^RFxDbAdAXhBl@nA\\?@~CdAzAj@xDfBvC~AXNb@VPHbAj@t@`@"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575109",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 6857.3,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:11:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:36:14-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Green Street",
-                "stop": {
-                  "name": "Green Street",
-                  "url": "https://www.mbta.com/stops/place-grnst",
-                  "gtfs_id": "mbta-ma-us-initial:70002",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-grnst"
-                  }
-                },
-                "lat": 42.309832,
-                "lon": -71.108059
-              },
-              "duration": 1514.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "msfaGjh_qL_B}@QMKO??QOIG\\y@BIBQBM?A?C?AZaAHS^eA`@yABEGERo@b@sAZaAFSBMDUP}@\\oBZmBRsADQBKNw@P_ABIN{@PqAR}ADUBOBOBM@CBGDIFMTo@PG^g@VU\\YPURa@Tq@Ni@XcAPo@@ED[?E@k@Ck@G{@GkAAUV[d@k@N]HWFWHs@Fu@@K@[?I@IBEIIGGEICICKAKEYCS?GCICSCQESCQEOEQCOEO??EMCOEKEMCMUo@EMGO_AsB_@{@EKEKv@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 67.67,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
-                },
-                {
-                  "distance": 19.37,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 11.89,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Woolsey Square, Green Street, Amory Street, Franklin Park/Zoo"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "EXIT_STATION",
-                  "street_name": "Green Street - Woolsey Sq, Green St, Amory St"
-                },
-                {
-                  "distance": 170.33,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "sidewalk"
-                },
-                {
-                  "distance": 5.09,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Union Avenue"
-                },
-                {
-                  "distance": 102.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "Green Street"
-                },
-                {
-                  "distance": 420.06,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "Glen Road"
-                },
-                {
-                  "distance": 318.77,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "SLIGHTLY_RIGHT",
-                  "street_name": "Glen Lane"
-                },
-                {
-                  "distance": 155.39,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "bike path"
-                },
-                {
-                  "distance": 294.71,
-                  "absolute_direction": "NORTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "Pierpont Road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 1929.63,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 2197.86,
-          "number_of_transfers": 1,
-          "duration": 4083,
-          "accessibility_score": null
-        },
-        {
-          "start": "2025-08-14T12:28:11-04:00",
-          "end": "2025-08-14T13:40:12-04:00",
-          "generalized_cost": 7702,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:30:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:55:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
-                  "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
-                  }
-                },
-                "lat": 42.396148,
-                "lon": -71.140698
-              },
-              "duration": 1.5e3,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
-                },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                },
-                {
-                  "name": "Downtown Crossing"
-                },
-                {
-                  "name": "South Station"
-                },
-                {
-                  "name": "Broadway"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]??HO~IqQj@cAp@wBr@kBj@kBHYDS??nDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCA??zlAm@"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349516",
-                "direction_id": "0",
-                "trip_headsign": "Braintree",
-                "trip_short_name": null
-              },
-              "distance": 13074.0,
-              "headsign": "Braintree",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:55:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:55:50-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:70083",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
-                  }
-                },
-                "lat": 42.330154,
-                "lon": -71.057655
-              },
-              "duration": 50.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "mrjaGjmupL??\\h@Fo@"
-              },
-              "steps": [
-                {
-                  "distance": 20.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
-                },
-                {
-                  "distance": 23.89,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "trip": null,
-              "distance": 56.2,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:06:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-08-14T13:33:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us-initial:16",
+                  "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                  "mode": "BUS",
+                  "short_name": "16",
+                  "sort_order": 50160,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:10:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
                   "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us-initial:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "from": {
-                "name": "Andrew",
-                "stop": {
-                  "name": "Andrew",
-                  "url": "https://www.mbta.com/stops/place-andrw",
-                  "gtfs_id": "mbta-ma-us-initial:13",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.329962,
-                "lon": -71.057625
-              },
-              "duration": 1620.0,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
-                "mode": "BUS",
-                "desc": "Local Bus",
-                "color": "FFC72C",
-                "sort_order": 50160,
-                "gtfs_id": "mbta-ma-us-initial:16",
-                "agency": {
-                  "name": "MBTA"
-                },
-                "short_name": "16",
-                "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "South Bay Mall @ Target"
-                },
-                {
-                  "name": "South Bay Mall opp Macy's"
-                },
-                {
-                  "name": "South Bay Mall @ Allstate Rd"
-                },
-                {
-                  "name": "Massachusetts Ave opp Clapp St"
-                },
-                {
-                  "name": "Massachusetts Ave @ Columbia Rd"
-                },
-                {
-                  "name": "Columbia Rd @ Holden St"
-                },
-                {
-                  "name": "Columbia Rd @ Dudley St"
-                },
-                {
-                  "name": "Columbia Rd @ Bird St"
-                },
-                {
-                  "name": "Columbia Rd @ Glendale St"
-                },
-                {
-                  "name": "Columbia Rd @ Quincy St"
-                },
-                {
-                  "name": "Columbia Rd @ Hamilton St"
-                },
-                {
-                  "name": "Columbia Rd opp Wyola Pl"
-                },
-                {
-                  "name": "Columbia Rd @ Devon St"
-                },
-                {
-                  "name": "Columbia Rd @ Geneva Ave"
-                },
-                {
-                  "name": "Columbia Rd @ Washington St"
-                },
-                {
-                  "name": "Columbia Rd @ Seaver St"
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:77172413",
+                  "trip_headsign": "Forest Hills",
+                  "trip_short_name": null
                 }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "arjaGdmupL?cCd@An@?`@Jm@tFm@jECR[hDWnBQ~ASbBAFg@lEET?VJRHPb@FNCHIHEDKBQ?iAA[?????Y@e@Dg@FSFOLQb@c@bB}ATQPGLAP?RBVFTHhFbCz@b@????tCzAXP\\RFD??FD^t@FPBPCXGn@T?NDRPh@nAHn@j@tAt@tBJIj@_@hByAn@g@r@o@JI??jAeAfEgD|BgBrAeA????~@s@X[NUD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@????VPrBnAp@b@\\^t@`AXj@JV????Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@????NHdD|ArBbAjAj@????NF\\ZtBbCdAtA\\h@\\v@P^??l@xAdAtCd@~@h@dA????JPpAbCZf@PVf@x@h@dAtA`Ct@nABB??`@h@l@x@|AlBTX??@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ????FTDp@Z|BTrANh@Vn@b@|@????HRPZ|@~ATj@v@xAj@z@Zl@??JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
               },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69702406",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills via South Bay Center",
-                "trip_short_name": null
-              },
-              "distance": 5043.52,
-              "headsign": "Forest Hills via South Bay Center",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:33:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:40:12-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
-              },
-              "from": {
-                "name": "Franklin Park Zoo @ Entrance",
-                "stop": {
+              {
+                "agency": null,
+                "distance": 533.36,
+                "duration": 440.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:34:20-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
                   "name": "Franklin Park Zoo @ Entrance",
-                  "url": "https://www.mbta.com/stops/1587",
-                  "gtfs_id": "mbta-ma-us-initial:1587",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "NO_INFORMATION",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
+                  }
                 },
-                "lat": 42.303124,
-                "lon": -71.08595
-              },
-              "duration": 432.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\GFA@MNCDEFEHENIr@CVABEPFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 34.79,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "Franklin Park Road"
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
                 },
-                {
-                  "distance": 13.01,
-                  "absolute_direction": "NORTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "path"
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:27:00-04:00"
                 },
-                {
-                  "distance": 51.01,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 34.79,
+                    "relative_direction": "DEPART",
+                    "street_name": "Franklin Park Road"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 13.01,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 51.01,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 305.25,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
                 },
-                {
-                  "distance": 417.83,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "LEFT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                }
-              ],
-              "trip": null,
-              "distance": 520.79,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 715.0699999999999,
-          "number_of_transfers": 1,
-          "duration": 4321,
-          "accessibility_score": null
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 1,
+            "start": "2026-08-14T14:35:13-04:00",
+            "walk_distance": 727.6400000000001
+          }
         },
         {
-          "start": "2025-08-14T12:34:11-04:00",
-          "end": "2025-08-14T13:42:04-04:00",
-          "generalized_cost": 8745,
-          "legs": [
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:36:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T12:55:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
+          "node": {
+            "accessibility_score": null,
+            "duration": 3778,
+            "end": "2026-08-14T15:48:11-04:00",
+            "generalized_cost": 9246,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:47:00-04:00"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Alewife",
-                "stop": {
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
                   "name": "Alewife",
-                  "url": "https://www.mbta.com/stops/place-alfcl",
-                  "gtfs_id": "mbta-ma-us-initial:70061",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:45:13-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.396148,
-                "lon": -71.140698
+                "transit_leg": false,
+                "trip": null
               },
-              "duration": 1140.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
-                "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "DA291C",
-                "sort_order": 10010,
-                "gtfs_id": "mbta-ma-us-initial:Red",
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Red Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Davis"
+                "distance": 9821.0,
+                "duration": 1140.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:06:00-04:00"
                 },
-                {
-                  "name": "Porter"
-                },
-                {
-                  "name": "Harvard"
-                },
-                {
-                  "name": "Central"
-                },
-                {
-                  "name": "Kendall/MIT"
-                },
-                {
-                  "name": "Charles/MGH"
-                },
-                {
-                  "name": "Park Street"
-                }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@???Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLT??T?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAP??j@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA????jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_B??DiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA??@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@???AZu@`DgIL]"
-              },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69349297",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
-              },
-              "distance": 9820.78,
-              "headsign": "Ashmont",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T12:55:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T12:56:49-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70077",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70075",
+                    "name": "Park Street"
                   }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]"
                 },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 109.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}poaGl}upL????????"
-              },
-              "steps": [
-                {
-                  "distance": 36.12,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Concourse | CharlieCard Store"
-                },
-                {
-                  "distance": 77.57,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                },
-                {
-                  "distance": 16.46,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Orange Line - Forest Hills"
-                }
-              ],
-              "trip": null,
-              "distance": 130.15,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:03:00-04:00",
-                "estimated": null
-              },
-              "mode": "SUBWAY",
-              "end": {
-                "scheduled_time": "2025-08-14T13:15:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
-                  "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
-                  }
-                },
-                "lat": 42.323132,
-                "lon": -71.099592
-              },
-              "from": {
-                "name": "Downtown Crossing",
-                "stop": {
-                  "name": "Downtown Crossing",
-                  "url": "https://www.mbta.com/stops/place-dwnxg",
-                  "gtfs_id": "mbta-ma-us-initial:70020",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
-                  }
-                },
-                "lat": 42.355518,
-                "lon": -71.060225
-              },
-              "duration": 720.0,
-              "transit_leg": true,
-              "route": {
-                "type": 1,
                 "mode": "SUBWAY",
-                "desc": "Rapid Transit",
-                "color": "ED8B00",
-                "sort_order": 10020,
-                "gtfs_id": "mbta-ma-us-initial:Orange",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:47:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76755299",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 130.15,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:07:47-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}poaGl}upL????????"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:06:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 36.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Concourse | CharlieCard Store"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 77.57,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 16.46,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  }
+                ],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": null,
-                "long_name": "Orange Line",
-                "text_color": "FFFFFF"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Chinatown"
+                "distance": 5215.0,
+                "duration": 660.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:25:00-04:00"
                 },
-                {
-                  "name": "Tufts Medical Center"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
                 },
-                {
-                  "name": "Back Bay"
+                "headsign": "Forest Hills",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70018",
+                    "name": "Chinatown"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70016",
+                    "name": "Tufts Medical Center"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70014",
+                    "name": "Back Bay"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70012",
+                    "name": "Massachusetts Avenue"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70010",
+                    "name": "Ruggles"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70008",
+                    "name": "Roxbury Crossing"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@?P@fD`@|B^XJRLx@`AzBvB^F\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvAfB`ClN`RfAtApCrD`@j@RVRT`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfAjBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
                 },
-                {
-                  "name": "Massachusetts Avenue"
+                "mode": "SUBWAY",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "ED8B00",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Orange",
+                  "long_name": "Orange Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10020,
+                  "text_color": "FFFFFF",
+                  "type": 1
                 },
-                {
-                  "name": "Ruggles"
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:14:00-04:00"
                 },
-                {
-                  "name": "Roxbury Crossing"
+                "steps": [],
+                "to": {
+                  "lat": 42.323132,
+                  "lon": -71.099592,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70006",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76855988",
+                  "trip_headsign": "Forest Hills",
+                  "trip_short_name": null
                 }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@???P@fD`@|B^XJRLx@`AzBvB^F??\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@??@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvA??fB`ClN`RfAtApCrD`@j@RVRT??`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfA??jBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
               },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69575115",
-                "direction_id": "0",
-                "trip_headsign": "Forest Hills",
-                "trip_short_name": null
-              },
-              "distance": 5215.25,
-              "headsign": "Forest Hills",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:15:00-04:00",
-                "estimated": null
-              },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:16:04-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Jackson Square",
-                "stop": {
+              {
+                "agency": null,
+                "distance": 71.02,
+                "duration": 63.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:26:03-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.323132,
+                  "lon": -71.099592,
                   "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70006",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "qfiaGns}pL????????Vv@KaA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:25:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 41.15,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 9.14,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 8.53,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to buses, Centre Street"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.323074,
+                  "lon": -71.099546,
                   "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:70006",
-                  "vehicle_mode": "SUBWAY",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "RapidTransit",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:11531",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.323132,
-                "lon": -71.099592
+                "transit_leg": false,
+                "trip": null
               },
-              "duration": 64.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "qfiaGns}pL????????Vv@KaA"
-              },
-              "steps": [
-                {
-                  "distance": 41.15,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street"
+              {
+                "agency": {
+                  "name": "MBTA"
                 },
-                {
-                  "distance": 0.0,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to street and buses"
+                "distance": 2101.0,
+                "duration": 540.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:40:00-04:00"
                 },
-                {
-                  "distance": 9.14,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "CONTINUE",
-                  "street_name": "pathway"
-                },
-                {
-                  "distance": 8.53,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Exit to buses, Centre Street"
-                },
-                {
-                  "distance": 12.19,
-                  "absolute_direction": "EAST",
-                  "relative_direction": "FOLLOW_SIGNS",
-                  "street_name": "Buses"
-                }
-              ],
-              "trip": null,
-              "distance": 71.02,
-              "headsign": null,
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:26:00-04:00",
-                "estimated": null
-              },
-              "mode": "BUS",
-              "end": {
-                "scheduled_time": "2025-08-14T13:34:00-04:00",
-                "estimated": null
-              },
-              "to": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
-                  "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us-initial:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
-                },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "from": {
-                "name": "Jackson Square",
-                "stop": {
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.323074,
+                  "lon": -71.099546,
                   "name": "Jackson Square",
-                  "url": "https://www.mbta.com/stops/place-jaksn",
-                  "gtfs_id": "mbta-ma-us-initial:11531",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": {
-                    "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:11531",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
                   }
                 },
-                "lat": 42.323074,
-                "lon": -71.099546
-              },
-              "duration": 480.0,
-              "transit_leg": true,
-              "route": {
-                "type": 3,
+                "headsign": "Ashmont",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:1265",
+                    "name": "Columbus Ave @ Dimock St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:1266",
+                    "name": "Columbus Ave opp Bray St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:10413",
+                    "name": "Columbus Ave @ Weld Ave - Egleston Sq"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:11413",
+                    "name": "Columbus Ave @ Walnut Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:17421",
+                    "name": "Seaver St opp Harold St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:17411",
+                    "name": "Seaver St opp Humboldt Ave"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCCl@?fBA~BEv@A~BAxBAzDGZ?NARCHEJGRSf@y@v@iADI??HOhAgBt@gAr@iApAsBNU??b@m@f@_ATi@XeAL]L[TUZUb@U@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]??PYxB_Dv@kAxB_DhBgCFK"
+                },
                 "mode": "BUS",
-                "desc": "Frequent Bus",
-                "color": "FFC72C",
-                "sort_order": 50220,
-                "gtfs_id": "mbta-ma-us-initial:22",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Frequent Bus",
+                  "gtfs_id": "mbta-ma-us-initial:22",
+                  "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
+                  "mode": "BUS",
+                  "short_name": "22",
+                  "sort_order": 50220,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:31:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.307515,
+                  "lon": -71.089263,
+                  "name": "Seaver St opp Elm Hill Ave",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:17401",
+                    "name": "Seaver St opp Elm Hill Ave",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/17401",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76573649",
+                  "trip_headsign": "Ashmont",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 626.45,
+                "duration": 491.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:48:11-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.307515,
+                  "lon": -71.089263,
+                  "name": "Seaver St opp Elm Hill Ave",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:17401",
+                    "name": "Seaver St opp Elm Hill Ave",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/17401",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@FAFEHId@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?DFBD@F?F@B?DB??B@BVGJQLg@LYNGLg@d@CFJDJF@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:40:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 244.74,
+                    "relative_direction": "DEPART",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHEAST",
+                    "distance": 99.91,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 89.98,
+                    "relative_direction": "RIGHT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 12.65,
+                    "relative_direction": "RIGHT",
+                    "street_name": "open area"
+                  },
+                  {
+                    "absolute_direction": "SOUTHEAST",
+                    "distance": 34.46,
+                    "relative_direction": "LEFT",
+                    "street_name": "open area"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 144.73,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 2,
+            "start": "2026-08-14T14:45:13-04:00",
+            "walk_distance": 965.7
+          }
+        },
+        {
+          "node": {
+            "accessibility_score": null,
+            "duration": 3872,
+            "end": "2026-08-14T15:49:45-04:00",
+            "generalized_cost": 11357,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:47:00-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:45:13-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
                 "agency": {
                   "name": "MBTA"
                 },
-                "short_name": "22",
-                "long_name": "Ashmont Station - Ruggles Station via Talbot Ave",
-                "text_color": "000000"
-              },
-              "agency": {
-                "name": "MBTA"
-              },
-              "realtime_state": "SCHEDULED",
-              "intermediate_stops": [
-                {
-                  "name": "Columbus Ave @ Dimock St"
+                "distance": 10360.0,
+                "duration": 1260.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:08:00-04:00"
                 },
-                {
-                  "name": "Columbus Ave opp Bray St"
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
                 },
-                {
-                  "name": "Columbus Ave @ Weld Ave - Egleston Sq"
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70075",
+                    "name": "Park Street"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]HO~IqQj@cAp@wBr@kBj@kBHYDS"
                 },
-                {
-                  "name": "Columbus Ave @ Walnut Ave"
+                "mode": "SUBWAY",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
                 },
-                {
-                  "name": "Seaver St opp Harold St"
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:47:00-04:00"
                 },
-                {
-                  "name": "Seaver St opp Humboldt Ave"
+                "steps": [],
+                "to": {
+                  "lat": 42.352271,
+                  "lon": -71.055242,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70079",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76755299",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
                 }
-              ],
-              "leg_geometry": {
-                "length": null,
-                "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCC??l@?fBA~BEv@A~BA??xBAzDGZ?NARCHEJGRSf@y@v@iADI????HOhAgBt@gAr@iApAsBNU????b@m@f@_ATi@XeAL]L[TUZUb@U??@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]????PYxB_Dv@kAxB_DhBgCFK"
               },
-              "steps": [],
-              "trip": {
-                "gtfs_id": "mbta-ma-us-initial:69703874",
-                "direction_id": "0",
-                "trip_headsign": "Ashmont",
-                "trip_short_name": null
+              {
+                "agency": null,
+                "distance": 178.88,
+                "duration": 133.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:10:13-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.352271,
+                  "lon": -71.055242,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70079",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "u|naGh~tpLYeA???FQb@dAPNGj@Qd@O^J"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:08:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "NORTHEAST",
+                    "distance": 47.85,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Commuter Rail, Amtrak, SL4 | Exits"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "HARD_RIGHT",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 6.1,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Bus Terminal, lobby, Amtrak, Silver Line - SL4 Nubian, Commuter Rail"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 17.63,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exits | SL4, Bus Terminal, Commuter Rail, Amtrak"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.83,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Bus Terminal, Commuter Rail, Amtrak, restrooms | Exits"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 9.46,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Tickets, information | Exits | Commuter Rail, Amtrak, Bus Terminal"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 23.77,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Commuter Rail, Amtrak, Bus Terminal"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 22.25,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - All trains, Silver Line - SL1/SL2/SL3 | Elevators"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 17.98,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Commuter Rail"
+                  }
+                ],
+                "to": {
+                  "lat": 42.351497,
+                  "lon": -71.055059,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:NEC-2287",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
               },
-              "distance": 2101.86,
-              "headsign": "Ashmont",
-              "real_time": false
-            },
-            {
-              "start": {
-                "scheduled_time": "2025-08-14T13:34:00-04:00",
-                "estimated": null
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 5711.0,
+                "duration": 780.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:30:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_cr_zone_1a",
+                      "medium": {
+                        "name": "mTicket app"
+                      },
+                      "name": "Commuter Rail Zone 1A one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_cr_zone_1a",
+                      "medium": {
+                        "name": "Credit/debit card"
+                      },
+                      "name": "Commuter Rail Zone 1A one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_cr_zone_1a",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Commuter Rail Zone 1A one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.351497,
+                  "lon": -71.055059,
+                  "name": "South Station",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:NEC-2287",
+                    "name": "South Station",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-sstat"
+                    },
+                    "url": "https://www.mbta.com/stops/place-sstat",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "headsign": "Readville via Fairmount",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:DB-2265-01",
+                    "name": "Newmarket"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:DB-2258-01",
+                    "name": "Uphams Corner"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "wwnaGz{tpL\\BjL~Er@XpDbBl@Zh@\\t@^hAp@fBfAvDzBvEnCFFHDJHjBdApAv@tAf@p@Nj@NLDPFR@b@@V?~@Av@A`AAhAAnDK|DGdHMxBEXDp@N`@Nh@XrAt@|A~@NJlE|BhBfAlAl@zAx@n@Z`@Rb@Rz@f@`@TbB~@f@T|@j@jCtAhFtCfCtA`B|@nCxApAp@JFXL|B`AtAd@dAVnAVpAVtBZdATjGfAbANpEv@rARdCb@HBfANXD`Et@F@`BZxA\\v@ThA^`Ab@tAh@fGbC~Al@PFFBZJtAh@fBt@`A^`C`AtCfAfA^~@`@bA`@\\LdChA|@f@v@d@`At@~@|@v@z@z@dAjBxBbCvCxA`Bx@bAr@t@v@v@v@l@FDLH"
+                },
+                "mode": "RAIL",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "80276C",
+                  "desc": "Regional Rail",
+                  "gtfs_id": "mbta-ma-us-initial:CR-Fairmount",
+                  "long_name": "Fairmount Line",
+                  "mode": "RAIL",
+                  "short_name": null,
+                  "sort_order": 20001,
+                  "text_color": "FFFFFF",
+                  "type": 2
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:17:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.303955,
+                  "lon": -71.077979,
+                  "name": "Four Corners/Geneva",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:DB-2249-01",
+                    "name": "Four Corners/Geneva",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-DB-2249"
+                    },
+                    "url": "https://www.mbta.com/stops/place-DB-2249",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:BaseJuly17Update-830504-1659",
+                  "trip_headsign": "Readville",
+                  "trip_short_name": "1659"
+                }
               },
-              "mode": "WALK",
-              "end": {
-                "scheduled_time": "2025-08-14T13:42:04-04:00",
-                "estimated": null
+              {
+                "agency": null,
+                "distance": 1445.71,
+                "duration": 1185.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:49:45-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.303955,
+                  "lon": -71.077979,
+                  "name": "Four Corners/Geneva",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:DB-2249-01",
+                    "name": "Four Corners/Geneva",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-DB-2249"
+                    },
+                    "url": "https://www.mbta.com/stops/place-DB-2249",
+                    "vehicle_mode": "RAIL",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "CR-zone-1A"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "speaG|jypL~BbB?BTt@sA~@BLDN@@WRoA|@]b@A@CBEF_C|CjA~BDHDH~@fBz@pAJPDFFHfAtADHFHLVFPFRBJBPBJ@JFb@BZ@^?n@CL@FAJAH?B@LBN@|@?BAH?B?DA??F@RBf@?L@D?BJNnAfCCBCDKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:30:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 82.3,
+                    "relative_direction": "DEPART",
+                    "street_name": "Track 1 (Outbound)"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 27.05,
+                    "relative_direction": "SLIGHTLY_RIGHT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 53.95,
+                    "relative_direction": "RIGHT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 209.68,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 587.16,
+                    "relative_direction": "LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 51.01,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 305.25,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 1,
+            "start": "2026-08-14T14:45:13-04:00",
+            "walk_distance": 1762.67
+          }
+        },
+        {
+          "node": {
+            "accessibility_score": null,
+            "duration": 4387,
+            "end": "2026-08-14T15:53:20-04:00",
+            "generalized_cost": 9113,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:42:00-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:40:13-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
               },
-              "to": {
-                "name": "Franklin Park Zoo",
-                "stop": null,
-                "lat": 42.305067,
-                "lon": -71.090434
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 13074.0,
+                "duration": 1.5e3,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:07:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Ashmont",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70075",
+                    "name": "Park Street"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70079",
+                    "name": "South Station"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70081",
+                    "name": "Broadway"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]HO~IqQj@cAp@wBr@kBj@kBHYDSnDmM^i@POl@UhAQj@Gb@?r@HZFj@Pz@b@fe@h[pCAzlAm@"
+                },
+                "mode": "SUBWAY",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:42:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76755003",
+                  "trip_headsign": "Ashmont",
+                  "trip_short_name": null
+                }
               },
-              "from": {
-                "name": "Seaver St opp Elm Hill Ave",
-                "stop": {
+              {
+                "agency": null,
+                "distance": 56.2,
+                "duration": 49.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:07:49-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.330154,
+                  "lon": -71.057655,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70083",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "mrjaGjmupL??\\h@Fo@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:07:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 20.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 23.89,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 1463.0,
+                "duration": 300.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:18:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.329962,
+                  "lon": -71.057625,
+                  "name": "Andrew",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:13",
+                    "name": "Andrew",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-andrw"
+                    },
+                    "url": "https://www.mbta.com/stops/place-andrw",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": "Fields Corner",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2905",
+                    "name": "Boston St @ Ellery St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2906",
+                    "name": "Boston St opp Washburn St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2907",
+                    "name": "Boston St @ W Howell St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2908",
+                    "name": "Boston St opp Harvest St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2909",
+                    "name": "Boston St opp Mayhew St"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "arjaGdmupL?cCd@An@?`@J^\\vBhAv@`@RHj@T`Bl@h@RxAd@j@RnAb@pAd@^J??lA\\\\LXJj@RVNRL`BfA~@l@??n@`@|@h@dAr@n@`@~@`@tA^XF??x@R\\DT?f@Aj@EX?PBNDRXD`@Lb@JTZd@Xh@`@d@\\`@`@^f@`@b@ZzA|@"
+                },
+                "mode": "BUS",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us-initial:17",
+                  "long_name": "Fields Corner Station - Andrew Station",
+                  "mode": "BUS",
+                  "short_name": "17",
+                  "sort_order": 50170,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:13:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.318764,
+                  "lon": -71.063583,
+                  "name": "Columbia Rd @ Holden St",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:362",
+                    "name": "Columbia Rd @ Holden St",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/362",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76572365",
+                  "trip_headsign": "Fields Corner",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 2627.0,
+                "duration": 1320.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:46:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_local_bus_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Local Bus one-way fare",
+                      "price": {
+                        "amount": 1.7
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.318764,
+                  "lon": -71.063583,
+                  "name": "Columbia Rd @ Holden St",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:362",
+                    "name": "Columbia Rd @ Holden St",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/362",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": "Forest Hills via South Bay Center",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2910",
+                    "name": "Columbia Rd @ Dudley St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2911",
+                    "name": "Columbia Rd @ Bird St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2912",
+                    "name": "Columbia Rd @ Glendale St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2913",
+                    "name": "Columbia Rd @ Quincy St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2914",
+                    "name": "Columbia Rd @ Hamilton St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2915",
+                    "name": "Columbia Rd opp Wyola Pl"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2916",
+                    "name": "Columbia Rd @ Devon St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2918",
+                    "name": "Columbia Rd @ Geneva Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2919",
+                    "name": "Columbia Rd @ Washington St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:2920",
+                    "name": "Columbia Rd @ Seaver St"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "_khaGxqvpL??VPrBnAp@b@\\^t@`AXj@JV??Tj@^r@PTzBlB~@v@l@d@f@b@zAhA|@l@??NHdD|ArBbAjAj@??NF\\ZtBbCdAtA\\h@\\v@P^l@xAdAtCd@~@h@dA??JPpAbCZf@PVf@x@h@dAtA`Ct@nABB`@h@l@x@|AlBTX@?JL|@fAv@jAj@bAZv@Xv@Nn@FZ??FTDp@Z|BTrANh@Vn@b@|@??HRPZ|@~ATj@v@xAj@z@Zl@JPj@j@f@r@Xn@Ph@Ft@DjAA`A@b@D|AFh@Z|@h@fA"
+                },
+                "mode": "BUS",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us-initial:16",
+                  "long_name": "Forest Hills Station - Andrew Station or Harbor Point",
+                  "mode": "BUS",
+                  "short_name": "16",
+                  "sort_order": 50160,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:24:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76573772",
+                  "trip_headsign": "Forest Hills via South Bay Center",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 533.36,
+                "duration": 440.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:53:20-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.303124,
+                  "lon": -71.08595,
+                  "name": "Franklin Park Zoo @ Entrance",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:1587",
+                    "name": "Franklin Park Zoo @ Entrance",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/1587",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "NO_INFORMATION",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "oieaGd~zpLFGf@`AKNCFHPq@p@IJBFHRu@v@CNMv@Ov@CPaAbAa@b@ONEDCBOPED_@`@SRi@j@[\\@BBBBDDB@DBBBD?D?D?B?B?@ADAB?B?B?@?B?D@@@B@@@??@?@?@ABGHEHEDE?G?EBCBC@AB?B?DD?BJEDD\\CVE?"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:46:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 34.79,
+                    "relative_direction": "DEPART",
+                    "street_name": "Franklin Park Road"
+                  },
+                  {
+                    "absolute_direction": "NORTHWEST",
+                    "distance": 13.01,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 51.01,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 305.25,
+                    "relative_direction": "LEFT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 129.33,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 2,
+            "start": "2026-08-14T14:40:13-04:00",
+            "walk_distance": 727.6400000000001
+          }
+        },
+        {
+          "node": {
+            "accessibility_score": null,
+            "duration": 3538,
+            "end": "2026-08-14T15:54:11-04:00",
+            "generalized_cost": 9006,
+            "legs": [
+              {
+                "agency": null,
+                "distance": 138.08,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:57:00-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": null
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "{nwaGjteqL?b@ANRKFE\\C?NHv@EGWV??a@]?SAcA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:55:13-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 21.46,
+                    "relative_direction": "DEPART",
+                    "street_name": "Minuteman/Linear Park Connector"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 33.95,
+                    "relative_direction": "HARD_LEFT",
+                    "street_name": "sidewalk"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 0.0,
+                    "relative_direction": "ENTER_STATION",
+                    "street_name": "Alewife Path East"
+                  },
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 72.01,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 10.67,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Red Line - Ashmont/Braintree"
+                  }
+                ],
+                "to": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 9821.0,
+                "duration": 1140.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:16:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.396148,
+                  "lon": -71.140698,
+                  "name": "Alewife",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70061",
+                    "name": "Alewife",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-alfcl"
+                    },
+                    "url": "https://www.mbta.com/stops/place-alfcl",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Braintree",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70063",
+                    "name": "Davis"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70065",
+                    "name": "Porter"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70067",
+                    "name": "Harvard"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70069",
+                    "name": "Central"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70071",
+                    "name": "Kendall/MIT"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70073",
+                    "name": "Charles/MGH"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70075",
+                    "name": "Park Street"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "aowaGjteqLCcFGsACa@SaC?CYu@e@}@u@k@u@Yu@OMEKOGQSkAMcAGw@UoDHmCd@sUZcJJsEPwHPkEPsCJmB^mDl@}DDYTgA@?Ly@\\iAt@qB`AwBn@aAl@m@b@Yn@SrBCrCMzQ_AzLTT?R@~l@fD`Np@lAHz@CbBa@fBi@n@q@d@iAb@}@Z_@PM\\Il@@dBHbAPj@JtAP|@J^@JCLMHULa@vCyNBILOvG_IdCiD`@e@Xa@d@qAhEcPtBcGfAuCtMqVn@qA??jByD`DoGb@eAj@cBLkAHqBLiGXcHXmJr@kR|@s^JsB@SF_BDiAr@gJVcH^_MH{CD}AL}DP}GL{CVmIN_D?QFoAB[D_ADoA@[Bs@BkABU@_@Fc@Lm@BGHa@La@^_AvJ_OrCwDj@iAb@aAtBsFb@iA`@aAt@qBVm@?AZu@`DgIL]"
+                },
+                "mode": "SUBWAY",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "DA291C",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Red",
+                  "long_name": "Red Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10010,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T14:57:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76755300",
+                  "trip_headsign": "Braintree",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 130.15,
+                "duration": 107.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:17:47-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70077",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}poaGl}upL????????"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:16:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 36.12,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Concourse | CharlieCard Store"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 77.57,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 16.46,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Orange Line - Forest Hills"
+                  }
+                ],
+                "to": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 5215.0,
+                "duration": 660.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:34:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "CharlieCard"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_quick_subway",
+                      "medium": {
+                        "name": "CharlieTicket"
+                      },
+                      "name": "Subway Quick Ticket",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_smartcard",
+                      "medium": {
+                        "name": "Contactless payment"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  },
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_rapid_transit_cash",
+                      "medium": {
+                        "name": "Cash"
+                      },
+                      "name": "Subway one-way fare",
+                      "price": {
+                        "amount": 2.4
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.355518,
+                  "lon": -71.060225,
+                  "name": "Downtown Crossing",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70020",
+                    "name": "Downtown Crossing",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-dwnxg"
+                    },
+                    "url": "https://www.mbta.com/stops/place-dwnxg",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": "Forest Hills",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70018",
+                    "name": "Chinatown"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70016",
+                    "name": "Tufts Medical Center"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70014",
+                    "name": "Back Bay"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70012",
+                    "name": "Massachusetts Avenue"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70010",
+                    "name": "Ruggles"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:70008",
+                    "name": "Roxbury Crossing"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "iqoaG~}upL?@@@t@r@hAtAjDdDb@d@t@r@TJj@Lj@@l@Bz@H@?P@fD`@|B^XJRLx@`AzBvB^F\\FvAVPP~GrRJb@B\\?d@OzCCbACrFAtG@jCA|FBv@@`B?jAHlAJ~AF`@@D@@Hd@FJRb@R^x@dAzAzBdB~BlHjJ^f@xAlBJJp@v@pBdCnDlEr@fA\\d@b@n@`@l@fAvAfB`ClN`RfAtApCrD`@j@RVRT`C`DRVlLzNNPdEpFPN~AhBn@l@NL^Z??|@v@xAfAjBvApAz@bAn@l@Zb@Vd@Pz@`@\\Rh@Rn@Xp@T|@R|@ZrA`@l@NZHtErAHBd@JbHtCd@R"
+                },
+                "mode": "SUBWAY",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "ED8B00",
+                  "desc": "Rapid Transit",
+                  "gtfs_id": "mbta-ma-us-initial:Orange",
+                  "long_name": "Orange Line",
+                  "mode": "SUBWAY",
+                  "short_name": null,
+                  "sort_order": 10020,
+                  "text_color": "FFFFFF",
+                  "type": 1
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:23:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.323132,
+                  "lon": -71.099592,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70006",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:76856004",
+                  "trip_headsign": "Forest Hills",
+                  "trip_short_name": null
+                }
+              },
+              {
+                "agency": null,
+                "distance": 71.02,
+                "duration": 63.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:35:03-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.323132,
+                  "lon": -71.099592,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:70006",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "SUBWAY",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "RapidTransit"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "qfiaGns}pL????????Vv@KaA"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:34:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 41.15,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 0.0,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to street and buses"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 9.14,
+                    "relative_direction": "CONTINUE",
+                    "street_name": "pathway"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 8.53,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Exit to buses, Centre Street"
+                  },
+                  {
+                    "absolute_direction": "EAST",
+                    "distance": 12.19,
+                    "relative_direction": "FOLLOW_SIGNS",
+                    "street_name": "Buses"
+                  }
+                ],
+                "to": {
+                  "lat": 42.323074,
+                  "lon": -71.099546,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:11531",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "transit_leg": false,
+                "trip": null
+              },
+              {
+                "agency": {
+                  "name": "MBTA"
+                },
+                "distance": 2102.0,
+                "duration": 420.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:46:00-04:00"
+                },
+                "fare_products": [
+                  {
+                    "product": {
+                      "id": "mbta-ma-us-initial:prod_free_fare",
+                      "medium": null,
+                      "name": "Free fare",
+                      "price": {
+                        "amount": 0.0
+                      }
+                    }
+                  }
+                ],
+                "from": {
+                  "lat": 42.323074,
+                  "lon": -71.099546,
+                  "name": "Jackson Square",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:11531",
+                    "name": "Jackson Square",
+                    "parent_station": {
+                      "gtfs_id": "mbta-ma-us-initial:place-jaksn"
+                    },
+                    "url": "https://www.mbta.com/stops/place-jaksn",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": "Mattapan via Franklin Field",
+                "interline_with_previous_leg": false,
+                "intermediate_stops": [
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:1265",
+                    "name": "Columbus Ave @ Dimock St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:1266",
+                    "name": "Columbus Ave opp Bray St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:10413",
+                    "name": "Columbus Ave @ Weld Ave - Egleston Sq"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:11413",
+                    "name": "Columbus Ave @ Walnut Ave"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:17421",
+                    "name": "Seaver St opp Harold St"
+                  },
+                  {
+                    "gtfs_id": "mbta-ma-us-initial:17411",
+                    "name": "Seaver St opp Humboldt Ave"
+                  }
+                ],
+                "leg_geometry": {
+                  "points": "cfiaGzr}pL`A^TqDDm@dDKH?xFGfCCl@?fBA~BEv@A~BAxBAzDGZ?NARCHEJGRSf@y@v@iADI??HOhAgBt@gAr@iApAsBNU??b@m@f@_ATi@XeAL]L[TUZUb@U@?f@Mt@GrAQjA]t@_@f@c@p@s@pAgBR]??PYxB_Dv@kAxB_DhBgCFK"
+                },
+                "mode": "BUS",
+                "real_time": false,
+                "realtime_state": "SCHEDULED",
+                "route": {
+                  "agency": {
+                    "name": "MBTA"
+                  },
+                  "color": "FFC72C",
+                  "desc": "Local Bus",
+                  "gtfs_id": "mbta-ma-us-initial:29",
+                  "long_name": "Mattapan Station - Jackson Square Station",
+                  "mode": "BUS",
+                  "short_name": "29",
+                  "sort_order": 50290,
+                  "text_color": "000000",
+                  "type": 3
+                },
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:39:00-04:00"
+                },
+                "steps": [],
+                "to": {
+                  "lat": 42.307515,
+                  "lon": -71.089263,
                   "name": "Seaver St opp Elm Hill Ave",
-                  "url": "https://www.mbta.com/stops/17401",
-                  "gtfs_id": "mbta-ma-us-initial:17401",
-                  "vehicle_mode": "BUS",
-                  "wheelchair_boarding": "POSSIBLE",
-                  "zone_id": "LocalBus",
-                  "parent_station": null
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:17401",
+                    "name": "Seaver St opp Elm Hill Ave",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/17401",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
                 },
-                "lat": 42.307515,
-                "lon": -71.089263
-              },
-              "duration": 484.0,
-              "transit_leg": false,
-              "route": null,
-              "agency": null,
-              "realtime_state": null,
-              "intermediate_stops": [],
-              "leg_geometry": {
-                "length": null,
-                "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@XQd@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?BEp@u@BCp@q@RQFJNVFJDJF@"
-              },
-              "steps": [
-                {
-                  "distance": 244.74,
-                  "absolute_direction": "WEST",
-                  "relative_direction": "DEPART",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 42.5,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
-                },
-                {
-                  "distance": 57.09,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "SLIGHTLY_LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 89.98,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "RIGHT",
-                  "street_name": "service road"
-                },
-                {
-                  "distance": 12.65,
-                  "absolute_direction": "SOUTHWEST",
-                  "relative_direction": "RIGHT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 156.98,
-                  "absolute_direction": "SOUTHEAST",
-                  "relative_direction": "LEFT",
-                  "street_name": "open area"
-                },
-                {
-                  "distance": 4.18,
-                  "absolute_direction": "SOUTH",
-                  "relative_direction": "LEFT",
-                  "street_name": "path"
+                "transit_leg": true,
+                "trip": {
+                  "direction_id": "0",
+                  "gtfs_id": "mbta-ma-us-initial:77061627",
+                  "trip_headsign": "Mattapan via Franklin Field",
+                  "trip_short_name": null
                 }
-              ],
-              "trip": null,
-              "distance": 608.11,
-              "headsign": null,
-              "real_time": false
-            }
-          ],
-          "walk_distance": 947.36,
-          "number_of_transfers": 2,
-          "duration": 4073,
-          "accessibility_score": null
+              },
+              {
+                "agency": null,
+                "distance": 626.45,
+                "duration": 491.0,
+                "end": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:54:11-04:00"
+                },
+                "fare_products": [],
+                "from": {
+                  "lat": 42.307515,
+                  "lon": -71.089263,
+                  "name": "Seaver St opp Elm Hill Ave",
+                  "stop": {
+                    "gtfs_id": "mbta-ma-us-initial:17401",
+                    "name": "Seaver St opp Elm Hill Ave",
+                    "parent_station": null,
+                    "url": "https://www.mbta.com/stops/17401",
+                    "vehicle_mode": "BUS",
+                    "wheelchair_boarding": "POSSIBLE",
+                    "zone_id": "LocalBus"
+                  }
+                },
+                "headsign": null,
+                "interline_with_previous_leg": false,
+                "intermediate_stops": null,
+                "leg_geometry": {
+                  "points": "}dfaG|r{pLMB@H?H?H?HAJCJAHEJ]bAEJEJGHGJIJEHCJEJCJCLAL?JAL?L@J@NDXJ`@^r@FJTf@v@o@H@FAFEHId@g@RS\\NJ?NANGJGJM?Ab@a@DKFJDHn@q@@?DFBD@F?F@B?DB??B@BVGJQLg@LYNGLg@d@CFJDJF@"
+                },
+                "mode": "WALK",
+                "real_time": false,
+                "realtime_state": null,
+                "route": null,
+                "start": {
+                  "estimated": null,
+                  "scheduled_time": "2026-08-14T15:46:00-04:00"
+                },
+                "steps": [
+                  {
+                    "absolute_direction": "WEST",
+                    "distance": 244.74,
+                    "relative_direction": "DEPART",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHEAST",
+                    "distance": 99.91,
+                    "relative_direction": "LEFT",
+                    "street_name": "path"
+                  },
+                  {
+                    "absolute_direction": "SOUTH",
+                    "distance": 89.98,
+                    "relative_direction": "RIGHT",
+                    "street_name": "service road"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 12.65,
+                    "relative_direction": "RIGHT",
+                    "street_name": "open area"
+                  },
+                  {
+                    "absolute_direction": "SOUTHEAST",
+                    "distance": 34.46,
+                    "relative_direction": "LEFT",
+                    "street_name": "open area"
+                  },
+                  {
+                    "absolute_direction": "SOUTHWEST",
+                    "distance": 144.73,
+                    "relative_direction": "RIGHT",
+                    "street_name": "path"
+                  }
+                ],
+                "to": {
+                  "lat": 42.305067,
+                  "lon": -71.090434,
+                  "name": "Franklin Park Zoo",
+                  "stop": null
+                },
+                "transit_leg": false,
+                "trip": null
+              }
+            ],
+            "number_of_transfers": 2,
+            "start": "2026-08-14T14:55:13-04:00",
+            "walk_distance": 965.7
+          }
         }
       ],
       "routing_errors": [],
-      "search_date_time": "2025-08-14T12:22:04-04:00"
+      "search_date_time": "2026-08-14T14:31:40-04:00"
     }
   }
 }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -86,6 +86,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
 
     def fare_product_factory do
       %FareProduct{
+        id: Faker.String.base64(8),
         medium_name: Faker.String.base64(8),
         name: Faker.Company.name(),
         usd_price: Faker.random_between(100, 1000) |> div(100)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -13,6 +13,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
 
     alias OpenTripPlannerClient.Schema.{
       Agency,
+      FareProduct,
       Geometry,
       IntermediateStop,
       Itinerary,
@@ -80,6 +81,14 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
     def agency_factory do
       %Agency{
         name: Faker.Util.pick(["MBTA", "Massport", "Logan Express"])
+      }
+    end
+
+    def fare_product_factory do
+      %FareProduct{
+        medium_name: Faker.String.base64(8),
+        name: Faker.Company.name(),
+        usd_price: Faker.random_between(100, 1000) |> div(100)
       }
     end
 
@@ -189,6 +198,7 @@ if Code.ensure_loaded?(ExMachina) and Code.ensure_loaded?(Faker) do
         distance: random_distance(),
         duration: duration,
         end: end_time,
+        fare_products: [],
         from: build(:place),
         interline_with_previous_leg: false,
         intermediate_stops: [],


### PR DESCRIPTION
Ticket: [🗺️ 💸 Spike: Try turning on GTFS fares V2 for OTP](https://app.asana.com/1/15492006741476/project/1204352509486278/task/1216769442870973?focus=true)

> [!TIP]
> To try this, adjust the OTP URL in `config.exs` to an application running with Fares V2 activated, as in [this PR](https://github.com/mbta/otp-deploy/pull/50).

[OpenTripPlanner documentation on FareProduct](https://docs.opentripplanner.org/api/dev-2.x/graphql-gtfs/types/FareProduct)

This adds fares to transit legs!

Each transit leg will have one or more `fare_products` which at minimum, describe a fare medium and price - e.g. $1.70 cash.

OTP's model is pretty layered, I decided to simplify it a bit when parsing, so this JSON response

```json
{
   "id": "mbta-ma-us:prod_rapid_transit_quick_subway",
   "medium": {
       "name": "CharlieTicket"
    },
    "name" "Subway QuickTicket",
    "price": {
        "amount": 2.4,
        "currency": {
            "code": "USD"
        }
    }
}
```

becomes parsed into:

```elixir
%OpenTripPlannerClient.Schema.FareProduct{
    usd_price: 2.4,
    name: "Subway Quick Ticket",
    medium_name: "CharlieTicket",
    id: "mbta-ma-us:prod_rapid_transit_quick_subway"
}
```

Fare products in subsequent transit legs may also have a populated `dependencies` field, which list fare products that are required to be used earlier in that trip for it to apply. An example might look like this:

```elixir
%OpenTripPlannerClient.Schema.FareProduct{
    usd_price: 0.7,
    name: "Subway transfer",
    medium_name: "Contactless payment",
    dependencies: [
        %OpenTripPlannerClient.Schema.DependentFareProduct{
             name: "Local Bus one-way fare",
             medium_name: "Contactless payment",
             id: "mbta-ma-us:prod_local_bus_smartcard"
         },
         %OpenTripPlannerClient.Schema.DependentFareProduct{
             name: "Local Bus one-way fare",
             medium_name: "CharlieCard",
             id: "mbta-ma-us:prod_local_bus_smartcard"
         }
    ],
    id: "mbta-ma-us:prod_transfer_local_bus_to_rapid_transit"
}
```